### PR TITLE
feat(ui): full redesign with sidebar app-shell and component layer

### DIFF
--- a/assets/logo.svg
+++ b/assets/logo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+  <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/>
+</svg>

--- a/css/components.css
+++ b/css/components.css
@@ -1,0 +1,542 @@
+/* ============================================================
+   Devtools — Component layer
+   Reusable primitives: button, input, field, card, alert,
+   chip, toolbar, switch, kbd, skeleton.
+   Legacy class aliases are included so existing tool pages
+   adopt the new look without markup edits.
+   ============================================================ */
+
+/* ============================================================
+   Button
+   ============================================================ */
+
+.btn,
+button.primary,
+button.secondary {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: var(--space-2);
+    height: 40px;
+    padding: 0 var(--space-4);
+    border-radius: var(--radius-md);
+    border: 1px solid transparent;
+    font-family: var(--font-display);
+    font-size: var(--text-sm);
+    font-weight: 500;
+    line-height: 1;
+    white-space: nowrap;
+    cursor: pointer;
+    user-select: none;
+    transition: background-color var(--duration-fast) var(--ease-out),
+                border-color var(--duration-fast) var(--ease-out),
+                color var(--duration-fast) var(--ease-out),
+                box-shadow var(--duration-fast) var(--ease-out),
+                transform var(--duration-fast) var(--ease-out);
+}
+
+.btn:focus-visible,
+button.primary:focus-visible,
+button.secondary:focus-visible {
+    outline: none;
+    box-shadow: var(--focus-ring);
+}
+
+.btn:disabled,
+button.primary:disabled,
+button.secondary:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+    transform: none !important;
+}
+
+/* Primary */
+.btn--primary,
+button.primary {
+    background-color: var(--accent-primary);
+    color: var(--text-on-accent);
+    border-color: var(--accent-primary);
+    box-shadow: var(--shadow-xs);
+}
+
+.btn--primary:hover:not(:disabled),
+button.primary:hover:not(:disabled) {
+    background-color: var(--accent-secondary);
+    border-color: var(--accent-secondary);
+    box-shadow: var(--shadow-sm);
+}
+
+.btn--primary:active:not(:disabled),
+button.primary:active:not(:disabled) {
+    transform: translateY(1px);
+    box-shadow: var(--shadow-xs);
+}
+
+/* Secondary (subtle surface) */
+.btn--secondary,
+button.secondary {
+    background-color: var(--surface-2);
+    color: var(--text-primary);
+    border-color: var(--border-color);
+}
+
+.btn--secondary:hover:not(:disabled),
+button.secondary:hover:not(:disabled) {
+    background-color: var(--surface-3);
+    border-color: var(--border-strong);
+}
+
+/* Ghost */
+.btn--ghost {
+    background-color: transparent;
+    color: var(--text-primary);
+    border-color: transparent;
+}
+
+.btn--ghost:hover:not(:disabled) {
+    background-color: var(--surface-2);
+}
+
+/* Danger */
+.btn--danger {
+    background-color: var(--danger);
+    color: #fff;
+    border-color: var(--danger);
+}
+
+.btn--danger:hover:not(:disabled) {
+    background-color: #b91c1c;
+    border-color: #b91c1c;
+}
+
+/* Icon-only */
+.btn--icon,
+button.icon-button {
+    width: 40px;
+    height: 40px;
+    padding: 0;
+    font-size: var(--text-base);
+}
+
+.btn--icon-sm {
+    width: 32px;
+    height: 32px;
+    font-size: var(--text-sm);
+}
+
+/* Sizes */
+.btn--sm { height: 32px; padding: 0 var(--space-3); font-size: var(--text-xs); }
+.btn--lg { height: 48px; padding: 0 var(--space-6); font-size: var(--text-base); }
+
+/* Copied feedback (used by main.js) */
+.btn.copied,
+button.copied {
+    background-color: var(--success) !important;
+    border-color: var(--success) !important;
+    color: #fff !important;
+}
+
+/* ============================================================
+   Input / Textarea / Select (component-class form)
+   Note: bare elements (`textarea`, `input[type=text]`, etc.)
+   are styled in theme.css so legacy tool pages still look good.
+   ============================================================ */
+
+.input,
+.textarea,
+.select {
+    display: block;
+    width: 100%;
+    height: 40px;
+    padding: 0 var(--space-3);
+    border-radius: var(--radius-md);
+    border: 1px solid var(--input-border);
+    background-color: var(--input-bg);
+    color: var(--text-primary);
+    font-family: inherit;
+    font-size: var(--text-sm);
+    transition: border-color var(--duration-fast) var(--ease-out),
+                box-shadow var(--duration-fast) var(--ease-out);
+}
+
+.textarea {
+    height: auto;
+    min-height: 150px;
+    padding: var(--space-3);
+    font-family: var(--font-mono);
+    resize: vertical;
+    line-height: var(--leading-normal);
+}
+
+.input:hover, .textarea:hover, .select:hover {
+    border-color: var(--input-border-hover);
+}
+
+.input:focus, .textarea:focus, .select:focus {
+    outline: none;
+    border-color: var(--input-border-focus);
+    box-shadow: var(--focus-ring);
+}
+
+.input--mono {
+    font-family: var(--font-mono);
+}
+
+/* ============================================================
+   Field (label + control + helper)
+   Legacy alias: .input-group
+   ============================================================ */
+
+.field,
+.input-group {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-2);
+    margin-bottom: var(--space-5);
+}
+
+.field__label,
+.input-group label {
+    display: block;
+    font-size: var(--text-sm);
+    font-weight: 600;
+    color: var(--text-primary);
+    margin-bottom: 0;
+}
+
+.field__hint {
+    font-size: var(--text-xs);
+    color: var(--text-muted);
+}
+
+.field__error {
+    font-size: var(--text-xs);
+    color: var(--danger);
+}
+
+/* ============================================================
+   Toolbar (button row)
+   Legacy alias: .input-controls
+   ============================================================ */
+
+.toolbar,
+.input-controls {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--space-2);
+    margin-top: var(--space-3);
+}
+
+.toolbar--end {
+    justify-content: flex-end;
+}
+
+.toolbar--between {
+    justify-content: space-between;
+}
+
+.toolbar__spacer {
+    flex: 1;
+}
+
+/* ============================================================
+   Card (generic surface)
+   ============================================================ */
+
+.card {
+    background-color: var(--surface-1);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-lg);
+    padding: var(--space-6);
+    box-shadow: var(--shadow-xs);
+}
+
+.card--interactive {
+    cursor: pointer;
+    transition: transform var(--duration-base) var(--ease-out),
+                box-shadow var(--duration-base) var(--ease-out),
+                border-color var(--duration-base) var(--ease-out);
+}
+
+.card--interactive:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-md);
+    border-color: var(--border-strong);
+}
+
+.card__title {
+    font-size: var(--text-lg);
+    font-weight: 600;
+    margin-bottom: var(--space-2);
+}
+
+.card__body {
+    color: var(--text-secondary);
+}
+
+/* ============================================================
+   Panel (boxed section inside tool pages)
+   ============================================================ */
+
+.panel {
+    background-color: var(--surface-1);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+}
+
+.panel__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--space-3) var(--space-4);
+    border-bottom: 1px solid var(--border-color);
+    background-color: var(--surface-2);
+    font-size: var(--text-sm);
+    font-weight: 600;
+}
+
+.panel__body {
+    padding: var(--space-5);
+}
+
+/* ============================================================
+   Chip / Tag (category badge)
+   ============================================================ */
+
+.chip,
+.tag,
+.category-tag {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-1);
+    padding: 2px var(--space-2);
+    border-radius: var(--radius-pill);
+    background-color: var(--accent-bg);
+    color: var(--accent-primary);
+    font-size: var(--text-xs);
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    line-height: 1.5;
+    border: 1px solid transparent;
+    white-space: nowrap;
+}
+
+.chip--solid {
+    background-color: var(--accent-primary);
+    color: var(--text-on-accent);
+}
+
+.chip--neutral {
+    background-color: var(--surface-3);
+    color: var(--text-secondary);
+}
+
+/* Category-specific chip colour (used on cards) */
+.chip[data-category="text"],          .category-tag[data-category="text"]          { background: rgba(249, 115, 22, 0.12); color: var(--cat-text); }
+.chip[data-category="encoding"],      .category-tag[data-category="encoding"]      { background: rgba(16, 185, 129, 0.12); color: var(--cat-encoding); }
+.chip[data-category="data format"],   .category-tag[data-category="data format"]   { background: rgba(99, 102, 241, 0.12); color: var(--cat-data); }
+.chip[data-category="web"],           .category-tag[data-category="web"]           { background: rgba(6, 182, 212, 0.12); color: var(--cat-web); }
+.chip[data-category="crypto"],        .category-tag[data-category="crypto"]        { background: rgba(239, 68, 68, 0.12); color: var(--cat-crypto); }
+.chip[data-category="time"],          .category-tag[data-category="time"]          { background: rgba(245, 158, 11, 0.12); color: var(--cat-time); }
+.chip[data-category="visual"],        .category-tag[data-category="visual"]        { background: rgba(236, 72, 153, 0.12); color: var(--cat-visual); }
+.chip[data-category="api"],           .category-tag[data-category="api"]           { background: rgba(139, 92, 246, 0.12); color: var(--cat-api); }
+.chip[data-category="network"],       .category-tag[data-category="network"]       { background: rgba(20, 184, 166, 0.12); color: var(--cat-network); }
+
+/* ============================================================
+   Alert / message
+   Legacy aliases: .error-message, .success-message
+   ============================================================ */
+
+.alert,
+.error-message,
+.success-message {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--space-2);
+    padding: var(--space-3) var(--space-4);
+    border-radius: var(--radius-md);
+    border: 1px solid transparent;
+    font-size: var(--text-sm);
+    line-height: var(--leading-normal);
+    margin-bottom: var(--space-4);
+}
+
+.alert--error,
+.error-message {
+    background-color: var(--error-bg);
+    color: var(--error-text);
+    border-color: rgba(220, 38, 38, 0.25);
+}
+
+.alert--success,
+.success-message {
+    background-color: var(--success-bg);
+    color: var(--success-text);
+    border-color: rgba(22, 163, 74, 0.25);
+}
+
+.alert--warning {
+    background-color: var(--warning-bg);
+    color: var(--warning-text);
+    border-color: rgba(217, 119, 6, 0.25);
+}
+
+.alert--info {
+    background-color: var(--info-bg);
+    color: var(--info-text);
+    border-color: rgba(2, 132, 199, 0.25);
+}
+
+/* ============================================================
+   Switch / Checkbox / Radio (subtle native styling)
+   ============================================================ */
+
+input[type="checkbox"],
+input[type="radio"] {
+    accent-color: var(--accent-primary);
+    width: 16px;
+    height: 16px;
+    cursor: pointer;
+}
+
+.switch {
+    position: relative;
+    display: inline-block;
+    width: 36px;
+    height: 20px;
+}
+
+.switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.switch__slider {
+    position: absolute;
+    inset: 0;
+    background-color: var(--border-strong);
+    border-radius: var(--radius-pill);
+    transition: background-color var(--duration-fast) var(--ease-out);
+}
+
+.switch__slider::before {
+    content: '';
+    position: absolute;
+    width: 14px;
+    height: 14px;
+    left: 3px;
+    top: 3px;
+    background-color: #fff;
+    border-radius: 50%;
+    transition: transform var(--duration-fast) var(--ease-out);
+}
+
+.switch input:checked + .switch__slider {
+    background-color: var(--accent-primary);
+}
+
+.switch input:checked + .switch__slider::before {
+    transform: translateX(16px);
+}
+
+/* ============================================================
+   Kbd (keyboard hint)
+   ============================================================ */
+
+.kbd {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 20px;
+    height: 20px;
+    padding: 0 var(--space-1);
+    background-color: var(--surface-3);
+    border: 1px solid var(--border-color);
+    border-bottom-width: 2px;
+    border-radius: var(--radius-sm);
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    color: var(--text-secondary);
+    line-height: 1;
+}
+
+/* ============================================================
+   Skeleton loader
+   ============================================================ */
+
+.skeleton {
+    background: linear-gradient(90deg,
+        var(--surface-2) 25%,
+        var(--surface-3) 50%,
+        var(--surface-2) 75%);
+    background-size: 200% 100%;
+    border-radius: var(--radius-sm);
+    animation: skeleton-shimmer 1.4s ease-in-out infinite;
+}
+
+@keyframes skeleton-shimmer {
+    0% { background-position: 200% 0; }
+    100% { background-position: -200% 0; }
+}
+
+/* ============================================================
+   Legacy tool page surfaces
+   Apply panel-like styling to existing markup without changes.
+   ============================================================ */
+
+.tool-content {
+    max-width: 1000px;
+    margin: 0 auto;
+}
+
+.tool-content textarea,
+.tool-content input[type="text"],
+.tool-content input[type="number"],
+.tool-content select {
+    width: 100%;
+}
+
+.options-group {
+    background-color: var(--surface-1);
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-lg);
+    padding: var(--space-4) var(--space-5);
+    margin-bottom: var(--space-5);
+}
+
+.options-group > label:first-child {
+    display: block;
+    font-size: var(--text-sm);
+    font-weight: 600;
+    color: var(--text-primary);
+    margin-bottom: var(--space-3);
+}
+
+.options-controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-4) var(--space-5);
+    align-items: center;
+}
+
+.options-controls label {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    font-size: var(--text-sm);
+    color: var(--text-secondary);
+    cursor: pointer;
+}
+
+.options-controls input[type="number"] {
+    width: 64px;
+    height: 32px;
+    text-align: center;
+}
+
+.result-container {
+    margin-top: var(--space-7);
+}

--- a/css/layout.css
+++ b/css/layout.css
@@ -1,0 +1,683 @@
+/* ============================================================
+   Devtools — Layout
+   App shell (sidebar + main), top bar, tool grid, tool card,
+   tool page layout, footer, responsive breakpoints.
+   ============================================================ */
+
+/* ============================================================
+   App shell
+   ============================================================ */
+
+.app-shell {
+    display: grid;
+    grid-template-columns: 260px 1fr;
+    min-height: 100vh;
+}
+
+.app-main {
+    display: flex;
+    flex-direction: column;
+    min-width: 0; /* prevent grid blowout */
+}
+
+/* ============================================================
+   Sidebar
+   ============================================================ */
+
+.sidebar {
+    position: sticky;
+    top: 0;
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+    background-color: var(--sidebar-bg);
+    border-right: 1px solid var(--sidebar-border);
+    overflow-y: auto;
+    z-index: 50;
+}
+
+.sidebar__brand {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    padding: var(--space-5) var(--space-5) var(--space-4);
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: var(--text-lg);
+    color: var(--text-primary);
+    letter-spacing: -0.02em;
+}
+
+.sidebar__brand-mark {
+    width: 32px;
+    height: 32px;
+    display: grid;
+    place-items: center;
+    border-radius: var(--radius-md);
+    background: linear-gradient(135deg, var(--accent-primary), var(--accent-secondary));
+    color: #fff;
+}
+
+.sidebar__brand-mark svg {
+    width: 18px;
+    height: 18px;
+}
+
+.sidebar__section {
+    padding: var(--space-4) var(--space-3);
+    border-top: 1px solid var(--sidebar-border);
+}
+
+.sidebar__section:first-of-type {
+    border-top: 0;
+}
+
+.sidebar__heading {
+    font-size: var(--text-xs);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-muted);
+    font-weight: 600;
+    padding: 0 var(--space-3);
+    margin-bottom: var(--space-2);
+}
+
+.sidebar__nav {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.sidebar__link {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-2);
+    padding: var(--space-2) var(--space-3);
+    border-radius: var(--radius-md);
+    color: var(--text-secondary);
+    font-size: var(--text-sm);
+    font-weight: 500;
+    cursor: pointer;
+    transition: background-color var(--duration-fast) var(--ease-out),
+                color var(--duration-fast) var(--ease-out);
+}
+
+.sidebar__link:hover {
+    background-color: var(--surface-2);
+    color: var(--text-primary);
+}
+
+.sidebar__link.is-active {
+    background-color: var(--accent-bg);
+    color: var(--accent-primary);
+}
+
+.sidebar__link-label {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+}
+
+.sidebar__link-icon {
+    width: 18px;
+    height: 18px;
+    display: inline-grid;
+    place-items: center;
+    font-size: 0.85rem;
+}
+
+.sidebar__count {
+    font-size: var(--text-xs);
+    color: var(--text-muted);
+    font-weight: 600;
+    background-color: var(--surface-2);
+    padding: 1px 8px;
+    border-radius: var(--radius-pill);
+}
+
+.sidebar__link.is-active .sidebar__count {
+    background-color: var(--accent-soft);
+    color: var(--accent-primary);
+}
+
+.sidebar__footer {
+    margin-top: auto;
+    padding: var(--space-4);
+    border-top: 1px solid var(--sidebar-border);
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-2);
+}
+
+.sidebar__footer-links {
+    display: flex;
+    gap: var(--space-1);
+}
+
+/* Mobile sidebar — slide-over */
+.sidebar-scrim {
+    position: fixed;
+    inset: 0;
+    background-color: rgba(15, 23, 42, 0.4);
+    backdrop-filter: blur(2px);
+    z-index: 49;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity var(--duration-base) var(--ease-out);
+}
+
+body.sidebar-open .sidebar-scrim {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+/* ============================================================
+   Top bar
+   ============================================================ */
+
+.top-bar {
+    position: sticky;
+    top: 0;
+    z-index: 30;
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    padding: var(--space-3) var(--space-6);
+    background-color: var(--header-bg);
+    backdrop-filter: saturate(180%) blur(10px);
+    -webkit-backdrop-filter: saturate(180%) blur(10px);
+    border-bottom: 1px solid var(--header-border);
+    min-height: 64px;
+}
+
+.top-bar__menu-btn {
+    display: none;
+    width: 40px;
+    height: 40px;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--radius-md);
+    border: 1px solid var(--border-color);
+    background-color: var(--surface-1);
+    color: var(--text-primary);
+    font-size: var(--text-base);
+}
+
+.top-bar__menu-btn:hover {
+    background-color: var(--surface-2);
+}
+
+.top-bar__title {
+    font-size: var(--text-md);
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.top-bar__search {
+    flex: 1;
+    max-width: 520px;
+    position: relative;
+    margin-left: auto;
+}
+
+.top-bar__search-input {
+    width: 100%;
+    height: 40px;
+    padding: 0 var(--space-9) 0 var(--space-9);
+    border-radius: var(--radius-md);
+    border: 1px solid var(--input-border);
+    background-color: var(--input-bg);
+    color: var(--text-primary);
+    font-size: var(--text-sm);
+    transition: border-color var(--duration-fast) var(--ease-out),
+                box-shadow var(--duration-fast) var(--ease-out);
+}
+
+.top-bar__search-input:hover {
+    border-color: var(--input-border-hover);
+}
+
+.top-bar__search-input:focus {
+    outline: none;
+    border-color: var(--input-border-focus);
+    box-shadow: var(--focus-ring);
+}
+
+.top-bar__search-icon {
+    position: absolute;
+    left: var(--space-3);
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--text-muted);
+    pointer-events: none;
+    font-size: var(--text-sm);
+}
+
+.top-bar__search-kbd {
+    position: absolute;
+    right: var(--space-3);
+    top: 50%;
+    transform: translateY(-50%);
+    pointer-events: none;
+}
+
+.top-bar__search-clear {
+    position: absolute;
+    right: var(--space-2);
+    top: 50%;
+    transform: translateY(-50%);
+    width: 24px;
+    height: 24px;
+    display: grid;
+    place-items: center;
+    border-radius: var(--radius-pill);
+    color: var(--text-muted);
+    background: transparent;
+}
+
+.top-bar__search-clear:hover {
+    background-color: var(--surface-3);
+    color: var(--text-primary);
+}
+
+.top-bar__actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+}
+
+/* Theme toggle */
+.theme-toggle-btn {
+    width: 40px;
+    height: 40px;
+    display: inline-grid;
+    place-items: center;
+    border-radius: var(--radius-md);
+    border: 1px solid var(--border-color);
+    background-color: var(--surface-1);
+    color: var(--text-primary);
+    transition: background-color var(--duration-fast) var(--ease-out),
+                border-color var(--duration-fast) var(--ease-out);
+}
+
+.theme-toggle-btn:hover {
+    background-color: var(--surface-2);
+    border-color: var(--border-strong);
+}
+
+.theme-toggle-btn:focus-visible {
+    outline: none;
+    box-shadow: var(--focus-ring);
+}
+
+.theme-toggle-btn svg {
+    width: 18px;
+    height: 18px;
+}
+
+.theme-toggle-btn .icon-sun,
+.theme-toggle-btn .icon-moon {
+    transition: opacity var(--duration-base) var(--ease-out),
+                transform var(--duration-base) var(--ease-out);
+}
+
+.theme-toggle-btn .icon-sun { display: none; }
+.theme-toggle-btn .icon-moon { display: block; }
+[data-theme="dark"] .theme-toggle-btn .icon-sun { display: block; }
+[data-theme="dark"] .theme-toggle-btn .icon-moon { display: none; }
+
+/* ============================================================
+   Content area (homepage)
+   ============================================================ */
+
+.content {
+    flex: 1 0 auto;
+    padding: var(--space-7) var(--space-6) var(--space-9);
+}
+
+.content__inner {
+    max-width: 1280px;
+    margin: 0 auto;
+}
+
+.hero-strip {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: var(--space-4);
+    margin-bottom: var(--space-7);
+}
+
+.hero-strip__title {
+    font-size: var(--text-2xl);
+    line-height: 1.15;
+    letter-spacing: -0.02em;
+    margin-bottom: var(--space-1);
+}
+
+.hero-strip__subtitle {
+    color: var(--text-secondary);
+    font-size: var(--text-sm);
+    max-width: 540px;
+}
+
+.hero-strip__meta {
+    color: var(--text-muted);
+    font-size: var(--text-xs);
+}
+
+.hero-strip__meta a {
+    color: var(--text-secondary);
+    font-weight: 500;
+}
+
+.hero-strip__meta a:hover {
+    color: var(--accent-primary);
+}
+
+/* ============================================================
+   Tool grid
+   ============================================================ */
+
+.tool-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: var(--space-5);
+}
+
+/* ============================================================
+   Tool card (new horizontal design)
+   ============================================================ */
+
+.tool-card {
+    position: relative;
+    display: grid;
+    grid-template-columns: 52px 1fr;
+    gap: var(--space-4);
+    padding: var(--space-5);
+    background-color: var(--surface-1);
+    border: 1px solid var(--border-color);
+    border-left: 3px solid var(--cat-other);
+    border-radius: var(--radius-lg);
+    color: var(--text-primary);
+    cursor: pointer;
+    overflow: hidden;
+    transition: transform var(--duration-base) var(--ease-out),
+                box-shadow var(--duration-base) var(--ease-out),
+                border-color var(--duration-base) var(--ease-out),
+                background-color var(--duration-base) var(--ease-out);
+}
+
+.tool-card:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-md);
+    border-color: var(--border-strong);
+}
+
+.tool-card:focus-visible {
+    outline: none;
+    box-shadow: var(--focus-ring);
+}
+
+.tool-card__icon {
+    width: 48px;
+    height: 48px;
+    display: grid;
+    place-items: center;
+    border-radius: var(--radius-md);
+    background-color: var(--surface-2);
+    color: var(--accent-primary);
+    font-size: 1.4rem;
+    flex-shrink: 0;
+}
+
+.tool-card__body {
+    min-width: 0;
+}
+
+.tool-card__title {
+    font-family: var(--font-display);
+    font-size: var(--text-md);
+    font-weight: 600;
+    color: var(--text-primary);
+    margin: 0 0 var(--space-1);
+    line-height: 1.25;
+    overflow-wrap: break-word;
+}
+
+.tool-card__desc {
+    font-size: var(--text-xs);
+    color: var(--text-secondary);
+    line-height: var(--leading-normal);
+    margin: 0;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+}
+
+.tool-card__chip {
+    margin-top: var(--space-3);
+}
+
+/* Category accents on cards */
+.tool-card[data-category="text"]        { border-left-color: var(--cat-text); }
+.tool-card[data-category="encoding"]    { border-left-color: var(--cat-encoding); }
+.tool-card[data-category="data format"] { border-left-color: var(--cat-data); }
+.tool-card[data-category="web"]         { border-left-color: var(--cat-web); }
+.tool-card[data-category="crypto"]      { border-left-color: var(--cat-crypto); }
+.tool-card[data-category="time"]        { border-left-color: var(--cat-time); }
+.tool-card[data-category="visual"]      { border-left-color: var(--cat-visual); }
+.tool-card[data-category="api"]         { border-left-color: var(--cat-api); }
+.tool-card[data-category="network"]     { border-left-color: var(--cat-network); }
+
+.tool-card[data-category="text"]        .tool-card__icon { color: var(--cat-text); }
+.tool-card[data-category="encoding"]    .tool-card__icon { color: var(--cat-encoding); }
+.tool-card[data-category="data format"] .tool-card__icon { color: var(--cat-data); }
+.tool-card[data-category="web"]         .tool-card__icon { color: var(--cat-web); }
+.tool-card[data-category="crypto"]      .tool-card__icon { color: var(--cat-crypto); }
+.tool-card[data-category="time"]        .tool-card__icon { color: var(--cat-time); }
+.tool-card[data-category="visual"]      .tool-card__icon { color: var(--cat-visual); }
+.tool-card[data-category="api"]         .tool-card__icon { color: var(--cat-api); }
+.tool-card[data-category="network"]     .tool-card__icon { color: var(--cat-network); }
+
+/* ============================================================
+   No results state
+   ============================================================ */
+
+.empty-state {
+    grid-column: 1 / -1;
+    text-align: center;
+    padding: var(--space-9) var(--space-6);
+    color: var(--text-muted);
+}
+
+.empty-state__icon {
+    font-size: 2rem;
+    margin-bottom: var(--space-3);
+    color: var(--text-muted);
+}
+
+.empty-state__title {
+    font-size: var(--text-md);
+    color: var(--text-primary);
+    margin-bottom: var(--space-2);
+}
+
+.no-results-message {
+    text-align: center;
+    padding: var(--space-9) var(--space-6);
+    color: var(--text-muted);
+    font-size: var(--text-md);
+}
+
+/* ============================================================
+   Tool page layout
+   Used by tool/*.html pages (no sidebar — minimal top bar)
+   ============================================================ */
+
+.tool-page-shell {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
+}
+
+.tool-page-shell .top-bar {
+    justify-content: flex-start;
+}
+
+.tool-page-shell .top-bar__back {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    height: 40px;
+    padding: 0 var(--space-3);
+    border-radius: var(--radius-md);
+    color: var(--text-secondary);
+    font-size: var(--text-sm);
+    font-weight: 500;
+    transition: background-color var(--duration-fast) var(--ease-out),
+                color var(--duration-fast) var(--ease-out);
+}
+
+.tool-page-shell .top-bar__back:hover {
+    background-color: var(--surface-2);
+    color: var(--text-primary);
+}
+
+.tool-container {
+    flex: 1 0 auto;
+    padding: var(--space-7) var(--space-6) var(--space-9);
+}
+
+.tool-container .container {
+    max-width: 1100px;
+}
+
+.tool-header {
+    text-align: center;
+    margin-bottom: var(--space-4);
+}
+
+.tool-header h1 {
+    font-size: var(--text-2xl);
+    margin-bottom: var(--space-2);
+}
+
+.tool-description {
+    max-width: 720px;
+    margin: 0 auto var(--space-7);
+    text-align: center;
+    color: var(--text-secondary);
+    font-size: var(--text-sm);
+}
+
+/* ============================================================
+   Footer
+   ============================================================ */
+
+.app-footer,
+footer {
+    flex-shrink: 0;
+    padding: var(--space-6) var(--space-6);
+    border-top: 1px solid var(--border-color);
+    background-color: var(--surface-1);
+    text-align: center;
+    color: var(--text-muted);
+    font-size: var(--text-xs);
+}
+
+.app-footer p,
+footer p {
+    margin: 0 0 var(--space-1);
+    color: var(--text-muted);
+}
+
+.app-footer a,
+footer a {
+    color: var(--text-secondary);
+    font-weight: 500;
+    margin: 0 var(--space-1);
+}
+
+.app-footer a:hover,
+footer a:hover {
+    color: var(--accent-primary);
+}
+
+/* ============================================================
+   Legacy homepage tools-grid alias
+   (kept so index.html works if not fully migrated)
+   ============================================================ */
+
+.tools-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+    gap: var(--space-5);
+}
+
+/* ============================================================
+   Responsive breakpoints
+   ============================================================ */
+
+@media (max-width: 1024px) {
+    .app-shell {
+        grid-template-columns: 220px 1fr;
+    }
+    .tool-grid,
+    .tools-grid {
+        grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    }
+}
+
+@media (max-width: 768px) {
+    .app-shell {
+        grid-template-columns: 1fr;
+    }
+    .sidebar {
+        position: fixed;
+        top: 0;
+        left: 0;
+        height: 100vh;
+        width: 280px;
+        max-width: 80vw;
+        transform: translateX(-100%);
+        transition: transform var(--duration-base) var(--ease-out);
+        box-shadow: var(--shadow-lg);
+    }
+    body.sidebar-open .sidebar {
+        transform: translateX(0);
+    }
+    .top-bar {
+        padding: var(--space-3) var(--space-4);
+    }
+    .top-bar__menu-btn {
+        display: inline-grid;
+    }
+    .content {
+        padding: var(--space-6) var(--space-4) var(--space-7);
+    }
+    .tool-grid,
+    .tools-grid {
+        grid-template-columns: 1fr;
+    }
+    .hero-strip {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+    .tool-container {
+        padding: var(--space-6) var(--space-4) var(--space-7);
+    }
+}
+
+@media (max-width: 480px) {
+    .top-bar__search-kbd {
+        display: none;
+    }
+    .top-bar__title {
+        display: none;
+    }
+}

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,460 +1,274 @@
-/* Base Styles */
+/* ============================================================
+   Devtools — Base styles & design tokens
+   This file contains only design tokens, resets, and base
+   typography. Layout lives in layout.css, components in
+   components.css, theme colours in theme.css.
+   ============================================================ */
+
 :root {
-    --font-primary: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
-    --font-mono: 'Courier New', Courier, monospace;
-    --border-radius: 8px;
-    --transition-speed: 0.3s;
-    --spacing-xs: 0.25rem;
-    --spacing-sm: 0.5rem;
-    --spacing-md: 1rem;
-    --spacing-lg: 1.5rem;
-    --spacing-xl: 2rem;
-    --spacing-xxl: 3rem;
+    /* Fonts */
+    --font-display: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    --font-body: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    --font-mono: 'JetBrains Mono', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Consolas, 'Courier New', monospace;
+
+    /* Type scale */
+    --text-xs: 0.75rem;     /* 12 */
+    --text-sm: 0.875rem;    /* 14 */
+    --text-base: 1rem;      /* 16 */
+    --text-md: 1.0625rem;   /* 17 */
+    --text-lg: 1.25rem;     /* 20 */
+    --text-xl: 1.5rem;      /* 24 */
+    --text-2xl: 2rem;       /* 32 */
+    --text-3xl: 2.5rem;     /* 40 */
+    --text-4xl: 3rem;       /* 48 */
+    --leading-tight: 1.25;
+    --leading-normal: 1.55;
+    --leading-relaxed: 1.7;
+
+    /* Spacing scale (4px base) */
+    --space-0: 0;
+    --space-1: 0.25rem;     /* 4 */
+    --space-2: 0.5rem;      /* 8 */
+    --space-3: 0.75rem;     /* 12 */
+    --space-4: 1rem;        /* 16 */
+    --space-5: 1.25rem;     /* 20 */
+    --space-6: 1.5rem;      /* 24 */
+    --space-7: 2rem;        /* 32 */
+    --space-8: 2.5rem;      /* 40 */
+    --space-9: 3rem;        /* 48 */
+    --space-10: 4rem;       /* 64 */
+
+    /* Legacy spacing aliases (keep existing tools working) */
+    --spacing-xs: var(--space-1);
+    --spacing-sm: var(--space-2);
+    --spacing-md: var(--space-4);
+    --spacing-lg: var(--space-6);
+    --spacing-xl: var(--space-7);
+    --spacing-xxl: var(--space-9);
+
+    /* Radius scale */
+    --radius-sm: 6px;
+    --radius-md: 10px;
+    --radius-lg: 14px;
+    --radius-xl: 20px;
+    --radius-pill: 999px;
+    --border-radius: var(--radius-md); /* legacy alias */
+
+    /* Shadow scale */
+    --shadow-xs: 0 1px 2px rgba(15, 23, 42, 0.04);
+    --shadow-sm: 0 1px 3px rgba(15, 23, 42, 0.06), 0 1px 2px rgba(15, 23, 42, 0.04);
+    --shadow-md: 0 4px 8px rgba(15, 23, 42, 0.06), 0 2px 4px rgba(15, 23, 42, 0.04);
+    --shadow-lg: 0 12px 24px rgba(15, 23, 42, 0.08), 0 4px 8px rgba(15, 23, 42, 0.04);
+    --shadow-xl: 0 24px 48px rgba(15, 23, 42, 0.12), 0 8px 16px rgba(15, 23, 42, 0.06);
+
+    /* Motion */
+    --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+    --ease-in-out: cubic-bezier(0.65, 0, 0.35, 1);
+    --duration-fast: 120ms;
+    --duration-base: 200ms;
+    --duration-slow: 320ms;
+    --transition-speed: var(--duration-base); /* legacy alias */
+
+    /* Focus ring */
+    --focus-ring: 0 0 0 3px var(--accent-soft, rgba(59, 130, 246, 0.35));
+
+    /* Breakpoints (exposed for JS) */
+    --bp-sm: 480px;
+    --bp-md: 768px;
+    --bp-lg: 1024px;
+    --bp-xl: 1280px;
+}
+
+/* ============================================================
+   Reset
+   ============================================================ */
+
+*, *::before, *::after {
+    box-sizing: border-box;
 }
 
 * {
     margin: 0;
     padding: 0;
-    box-sizing: border-box;
+}
+
+html {
+    -webkit-text-size-adjust: 100%;
+    text-size-adjust: 100%;
 }
 
 html, body {
     height: 100%;
-    font-family: var(--font-primary);
-    line-height: 1.6;
-    transition: background-color var(--transition-speed), color var(--transition-speed);
 }
 
 body {
+    font-family: var(--font-body);
+    font-size: var(--text-base);
+    line-height: var(--leading-normal);
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
     display: flex;
     flex-direction: column;
     min-height: 100vh;
-}
-
-.container {
-    width: 100%;
-    max-width: 1200px;
-    margin: 0 auto;
-    padding: 0 var(--spacing-md);
+    transition: background-color var(--duration-base) var(--ease-out),
+                color var(--duration-base) var(--ease-out);
 }
 
 a {
+    color: inherit;
     text-decoration: none;
-    transition: color var(--transition-speed);
+    transition: color var(--duration-fast) var(--ease-out);
 }
 
 button {
     cursor: pointer;
-    font-family: var(--font-primary);
-    border: none;
-    border-radius: var(--border-radius);
-    transition: background-color var(--transition-speed), color var(--transition-speed);
+    font-family: inherit;
+    font-size: inherit;
+    border: 0;
+    background: transparent;
+    color: inherit;
+}
+
+input, textarea, select {
+    font-family: inherit;
+    font-size: inherit;
+    color: inherit;
 }
 
 ul {
     list-style: none;
 }
 
-/* Header */
-header {
-    padding: var(--spacing-md) 0;
-    position: sticky;
-    top: 0;
-    z-index: 100;
-}
-
-header .container {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-}
-
-.logo a {
-    font-size: 1.5rem;
-    font-weight: bold;
-}
-
-nav ul {
-    display: flex;
-    gap: var(--spacing-lg);
-}
-
-.theme-toggle button {
-    background: none;
-    border: none;
-    font-size: 1.2rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: var(--spacing-xs);
-}
-
-/* Hero Section */
-.hero {
-    text-align: center;
-    padding: var(--spacing-xxl) 0;
-}
-
-.hero h1 {
-    font-size: 3rem;
-    margin-bottom: var(--spacing-md);
-}
-
-.hero p {
-    font-size: 1.2rem;
-    max-width: 600px;
-    margin: 0 auto;
-}
-
-.credits {
-    margin-top: var(--spacing-md);
-    font-size: 0.9rem;
-}
-
-.credits p {
-    font-size: 0.9rem;
-    opacity: 0.8;
-}
-
-.credits a {
-    font-weight: 500;
-    text-decoration: underline;
-    text-decoration-thickness: 1px;
-    text-underline-offset: 2px;
-}
-
-/* Tools Grid */
-.tools {
-    padding: var(--spacing-xxl) 0;
-}
-
-.tools h2 {
-    text-align: center;
-    margin-bottom: var(--spacing-xl);
-}
-
-/* Search and Filter */
-.search-filter-container {
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--spacing-md);
-    justify-content: center;
-    margin-bottom: var(--spacing-xl);
-    margin-top: var(--spacing-lg);
-}
-
-.search-container {
-    position: relative;
-    flex: 1;
-    max-width: 500px;
-    min-width: 250px;
-}
-
-.search-icon {
-    position: absolute;
-    right: var(--spacing-md);
-    top: 50%;
-    transform: translateY(-50%);
-    color: var(--accent-primary);
-    font-size: 1.1rem;
-    opacity: 0.8;
-    pointer-events: none;
-    transition: right 0.2s ease;
-}
-
-.search-clear-btn {
-    position: absolute;
-    right: calc(var(--spacing-md) * 2.5);
-    top: 50%;
-    transform: translateY(-50%);
-    background: none;
-    border: none;
-    color: var(--text-secondary);
-    font-size: 1.2rem;
-    cursor: pointer;
-    padding: 0;
-    width: 24px;
-    height: 24px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    border-radius: 50%;
-    transition: all 0.2s ease;
-    z-index: 2;
-}
-
-.search-clear-btn:hover {
-    background-color: rgba(0, 0, 0, 0.05);
-    color: var(--text-primary);
-}
-
-[data-theme="dark"] .search-clear-btn:hover {
-    background-color: rgba(255, 255, 255, 0.1);
-}
-
-.search-clear-btn.hidden {
-    display: none;
-}
-
-.search-input {
-    width: 100%;
-    padding: var(--spacing-md);
-    padding-right: calc(var(--spacing-md) * 2.5);
-    border-radius: var(--border-radius);
-    border: 1px solid var(--border-color);
-    font-size: 1rem;
-    background-color: var(--input-bg);
-    color: var(--text-primary);
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
-    transition: all 0.3s ease;
-}
-
-.search-input:focus {
-    outline: none;
-    border-color: var(--primary-color);
-    box-shadow: 0 0 0 2px rgba(var(--primary-color-rgb), 0.2);
-}
-
-.search-input:focus + .search-icon {
-    opacity: 1;
-}
-
-.filter-container {
-    display: flex;
-    align-items: center;
-    gap: var(--spacing-sm);
-}
-
-.filter-label {
-    font-weight: 500;
-    color: var(--text-primary);
-}
-
-.category-select {
-    padding: var(--spacing-sm) var(--spacing-md);
-    border-radius: var(--border-radius);
-    border: 1px solid var(--border-color);
-    background-color: var(--input-bg);
-    color: var(--text-primary);
-    font-size: 0.9rem;
-    cursor: pointer;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
-    transition: all 0.3s ease;
-    min-width: 180px;
-}
-
-.category-select:focus {
-    outline: none;
-    border-color: var(--primary-color);
-    box-shadow: 0 0 0 2px rgba(var(--primary-color-rgb), 0.2);
-}
-
-.category-select:hover {
-    border-color: var(--primary-color);
-}
-
-.category-tag {
-    position: absolute;
-    top: var(--spacing-sm);
-    right: var(--spacing-sm);
-    font-size: 0.7rem;
-    padding: 3px 8px;
-    border-radius: 12px;
-    background-color: var(--primary-color);
-    color: white;
-    opacity: 0.85;
-    font-weight: 500;
-    letter-spacing: 0.5px;
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
-    transition: transform 0.2s ease, opacity 0.2s ease;
-}
-
-.tool-card:hover .category-tag {
-    transform: translateY(-2px);
-    opacity: 1;
-}
-
-.no-results-message {
-    text-align: center;
-    padding: var(--spacing-xl);
-    font-size: 1.1rem;
-    color: var(--text-secondary);
-}
-
-.tools-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-    gap: var(--spacing-lg);
-}
-
-.tool-card {
-    padding: var(--spacing-lg);
-    border-radius: var(--border-radius);
-    text-align: center;
-    transition: transform var(--transition-speed), box-shadow var(--transition-speed);
-}
-
-.tool-card:hover {
-    transform: translateY(-5px);
-}
-
-.tool-icon {
-    font-size: 2.5rem;
-    margin-bottom: var(--spacing-md);
-}
-
-.tool-card h3 {
-    margin-bottom: var(--spacing-sm);
-}
-
-.tool-card p {
-    font-size: 0.9rem;
-    color: var(--text-secondary);
-}
-
-/* Main content area */
-main {
-    flex: 1 0 auto; /* This allows main to grow and take available space */
-}
-
-/* Footer */
-footer {
-    flex-shrink: 0; /* Prevents footer from shrinking */
-    text-align: center;
-    padding: var(--spacing-xl) 0;
-    width: 100%;
-    position: relative;
-    z-index: 10;
-    box-shadow: 0 -1px 3px rgba(0, 0, 0, 0.05);
-}
-
-footer p {
-    margin-bottom: var(--spacing-sm);
-}
-
-footer a {
-    margin: 0 var(--spacing-xs);
-}
-
-/* Tool Pages */
-.tool-container {
-    padding: var(--spacing-xl) 0;
-}
-
-.tool-header {
-    text-align: center;
-    margin-bottom: var(--spacing-xl);
-}
-
-.tool-description {
-    max-width: 800px;
-    margin: 0 auto var(--spacing-xl);
-    text-align: center;
-}
-
-.tool-content {
-    max-width: 1000px;
-    margin: 0 auto;
-}
-
-.input-group {
-    margin-bottom: var(--spacing-lg);
-}
-
-.input-group label {
+img, svg {
     display: block;
-    margin-bottom: var(--spacing-xs);
-    font-weight: bold;
+    max-width: 100%;
 }
 
-.input-controls {
-    display: flex;
-    gap: var(--spacing-sm);
-    margin-top: var(--spacing-sm);
+/* Skip link for accessibility */
+.skip-link {
+    position: absolute;
+    top: -40px;
+    left: var(--space-4);
+    padding: var(--space-2) var(--space-4);
+    background: var(--accent-primary);
+    color: #fff;
+    border-radius: var(--radius-md);
+    z-index: 1000;
+    transition: top var(--duration-fast) var(--ease-out);
 }
 
-textarea, input[type="text"] {
-    width: 100%;
-    padding: var(--spacing-sm);
-    border-radius: var(--border-radius);
+.skip-link:focus {
+    top: var(--space-2);
+    outline: none;
+    box-shadow: var(--focus-ring);
+}
+
+/* ============================================================
+   Typography
+   ============================================================ */
+
+h1, h2, h3, h4, h5, h6 {
+    font-family: var(--font-display);
+    line-height: var(--leading-tight);
+    color: var(--text-primary);
+    letter-spacing: -0.01em;
+    font-weight: 700;
+}
+
+h1 { font-size: var(--text-3xl); }
+h2 { font-size: var(--text-2xl); }
+h3 { font-size: var(--text-lg); font-weight: 600; }
+h4 { font-size: var(--text-md); font-weight: 600; }
+h5 { font-size: var(--text-base); font-weight: 600; }
+h6 { font-size: var(--text-sm); font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; }
+
+p {
+    color: var(--text-secondary);
+}
+
+code, pre {
     font-family: var(--font-mono);
-    resize: vertical;
-    min-height: 150px;
-    transition: border-color var(--transition-speed);
+    font-size: 0.95em;
 }
 
-input[type="text"] {
-    min-height: auto;
+::selection {
+    background-color: var(--selection-bg);
+    color: var(--selection-text);
 }
 
-button.primary {
-    padding: var(--spacing-sm) var(--spacing-lg);
-    font-weight: bold;
+/* ============================================================
+   Scrollbar
+   ============================================================ */
+
+::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
 }
 
-button.icon-button {
-    padding: var(--spacing-xs);
-    font-size: 1rem;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+::-webkit-scrollbar-track {
+    background: var(--scrollbar-track);
 }
 
-.result-container {
-    margin-top: var(--spacing-xl);
+::-webkit-scrollbar-thumb {
+    background: var(--scrollbar-thumb);
+    border-radius: var(--radius-pill);
+    border: 2px solid var(--scrollbar-track);
 }
 
-.error-message {
-    padding: var(--spacing-md);
-    border-radius: var(--border-radius);
-    margin-bottom: var(--spacing-md);
+::-webkit-scrollbar-thumb:hover {
+    background: var(--scrollbar-thumb-hover);
 }
 
-/* Responsive Design */
-@media (max-width: 768px) {
-    .hero h1 {
-        font-size: 2.5rem;
+/* ============================================================
+   Utility classes
+   ============================================================ */
+
+.hidden { display: none !important; }
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.flex { display: flex; }
+.flex-column { flex-direction: column; }
+.justify-between { justify-content: space-between; }
+.align-center { align-items: center; }
+.text-center { text-align: center; }
+.text-muted { color: var(--text-secondary); }
+
+.mt-1 { margin-top: var(--space-2); }
+.mt-2 { margin-top: var(--space-4); }
+.mt-3 { margin-top: var(--space-6); }
+.mt-4 { margin-top: var(--space-7); }
+.mb-1 { margin-bottom: var(--space-2); }
+.mb-2 { margin-bottom: var(--space-4); }
+.mb-3 { margin-bottom: var(--space-6); }
+.mb-4 { margin-bottom: var(--space-7); }
+
+/* Reduced motion */
+@media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
     }
-    
-    .hero p {
-        font-size: 1rem;
-    }
-    
-    .tools-grid, .features-grid {
-        grid-template-columns: 1fr;
-    }
 }
 
-/* Utility Classes */
-.hidden {
-    display: none;
-}
+/* ============================================================
+   Container (legacy — used on tool pages without app-shell)
+   ============================================================ */
 
-.flex {
-    display: flex;
+.container {
+    width: 100%;
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 var(--space-4);
 }
-
-.flex-column {
-    flex-direction: column;
-}
-
-.justify-between {
-    justify-content: space-between;
-}
-
-.align-center {
-    align-items: center;
-}
-
-.text-center {
-    text-align: center;
-}
-
-.mt-1 { margin-top: var(--spacing-sm); }
-.mt-2 { margin-top: var(--spacing-md); }
-.mt-3 { margin-top: var(--spacing-lg); }
-.mt-4 { margin-top: var(--spacing-xl); }
-.mb-1 { margin-bottom: var(--spacing-sm); }
-.mb-2 { margin-bottom: var(--spacing-md); }
-.mb-3 { margin-bottom: var(--spacing-lg); }
-.mb-4 { margin-bottom: var(--spacing-xl); }

--- a/css/theme.css
+++ b/css/theme.css
@@ -1,348 +1,276 @@
-/* Theme Variables */
+/* ============================================================
+   Devtools — Theme (colour palette + theme-driven styling)
+   ============================================================ */
+
 :root {
-    /* Light Theme (Default) - Enhanced for better harmony and visual appeal */
-    /* Background colors with subtle gradients */
-    --bg-primary: #f8fafc;
-    --bg-secondary: #f1f5f9;
-    --bg-tertiary: #e2e8f0;
-    /* Text colors with better contrast */
-    --text-primary: #1e293b;
-    --text-secondary: #475569;
-    /* Vibrant accent colors */
+    /* Neutral scale — light */
+    --neutral-50: #f8fafc;
+    --neutral-100: #f1f5f9;
+    --neutral-200: #e2e8f0;
+    --neutral-300: #cbd5e1;
+    --neutral-400: #94a3b8;
+    --neutral-500: #64748b;
+    --neutral-600: #475569;
+    --neutral-700: #334155;
+    --neutral-800: #1e293b;
+    --neutral-900: #0f172a;
+
+    /* Surfaces */
+    --bg-primary: var(--neutral-50);
+    --bg-secondary: #ffffff;
+    --bg-tertiary: var(--neutral-100);
+    --surface-1: #ffffff;
+    --surface-2: var(--neutral-50);
+    --surface-3: var(--neutral-100);
+    --surface-raised: #ffffff;
+
+    /* Text */
+    --text-primary: var(--neutral-900);
+    --text-secondary: var(--neutral-600);
+    --text-muted: var(--neutral-500);
+    --text-on-accent: #ffffff;
+
+    /* Borders */
+    --border-color: var(--neutral-200);
+    --border-strong: var(--neutral-300);
+
+    /* Accent (brand) */
     --accent-primary: #3b82f6;
     --accent-secondary: #2563eb;
-    --border-color: #e2e8f0;
-    /* Card styling with subtle shadows */
-    --card-bg: linear-gradient(145deg, #ffffff, #f8fafc);
-    --card-shadow: 0 4px 10px rgba(0, 0, 0, 0.05), 0 2px 4px rgba(0, 0, 0, 0.03);
-    /* Status colors */
-    --error-bg: #fee2e2;
-    --error-text: #b91c1c;
+    --accent-strong: #1d4ed8;
+    --accent-soft: rgba(59, 130, 246, 0.18);
+    --accent-bg: rgba(59, 130, 246, 0.08);
+    --primary-color: var(--accent-primary);          /* legacy */
+    --primary-color-rgb: 59, 130, 246;                /* legacy */
+
+    /* Semantic */
+    --success: #16a34a;
     --success-bg: #dcfce7;
     --success-text: #166534;
-    /* Code blocks */
-    --code-bg: #f1f5f9;
-    --code-text: #1e293b;
-    /* Header with subtle transparency */
-    --header-bg: rgba(248, 250, 252, 0.95);
-    /* Buttons with gradients */
-    --button-bg: linear-gradient(135deg, #3b82f6, #2563eb);
-    --button-text: #ffffff;
-    --button-hover: linear-gradient(135deg, #2563eb, #1d4ed8);
-    /* Form elements */
+    --warning: #d97706;
+    --warning-bg: #fef3c7;
+    --warning-text: #92400e;
+    --danger: #dc2626;
+    --error-bg: #fee2e2;
+    --error-text: #b91c1c;
+    --info: #0284c7;
+    --info-bg: #e0f2fe;
+    --info-text: #075985;
+
+    /* Category accents — each tool category gets a hue */
+    --cat-text: #f97316;       /* orange */
+    --cat-encoding: #10b981;   /* emerald */
+    --cat-data: #6366f1;       /* indigo */
+    --cat-web: #06b6d4;        /* cyan */
+    --cat-crypto: #ef4444;     /* red */
+    --cat-time: #f59e0b;       /* amber */
+    --cat-visual: #ec4899;     /* pink */
+    --cat-api: #8b5cf6;        /* violet */
+    --cat-network: #14b8a6;    /* teal */
+    --cat-other: var(--neutral-400);
+
+    /* Inputs / forms */
     --input-bg: #ffffff;
-    --input-border-focus: rgba(59, 130, 246, 0.4);
-    /* Primary theme color */
-    --primary-color: #3b82f6;
-    --primary-color-rgb: 59, 130, 246;
-    /* Scrollbar styling */
-    --scrollbar-track: #f1f5f9;
-    --scrollbar-thumb: #cbd5e0;
-    --scrollbar-thumb-hover: #94a3b8;
-    /* Selection styling */
-    --selection-bg: rgba(59, 130, 246, 0.2);
-    --selection-text: #1e293b;
+    --input-border: var(--neutral-200);
+    --input-border-hover: var(--neutral-300);
+    --input-border-focus: var(--accent-primary);
+
+    /* Buttons (legacy gradients kept as fallback) */
+    --button-bg: var(--accent-primary);
+    --button-bg-hover: var(--accent-secondary);
+    --button-text: #ffffff;
+    --button-hover: var(--accent-secondary);
+
+    /* Code blocks */
+    --code-bg: var(--neutral-100);
+    --code-text: var(--neutral-800);
+
+    /* Header / sidebar */
+    --header-bg: rgba(255, 255, 255, 0.85);
+    --header-border: var(--neutral-200);
+    --sidebar-bg: #ffffff;
+    --sidebar-border: var(--neutral-200);
+
+    /* Scrollbar */
+    --scrollbar-track: transparent;
+    --scrollbar-thumb: var(--neutral-300);
+    --scrollbar-thumb-hover: var(--neutral-400);
+
+    /* Selection */
+    --selection-bg: rgba(59, 130, 246, 0.22);
+    --selection-text: var(--neutral-900);
 }
 
-/* Dark Theme - Enhanced for better readability, reduced eye strain, and visual appeal */
+/* ============================================================
+   Dark theme
+   ============================================================ */
+
 [data-theme="dark"] {
-    /* Darker background with better contrast */
-    --bg-primary: #0f1117;
-    --bg-secondary: #161b22;
-    --bg-tertiary: #21262d;
-    /* Brighter text for better readability */
-    --text-primary: #ffffff;
-    --text-secondary: #d1d5db;
-    /* More vibrant accent colors */
+    --neutral-50: #f8fafc;
+    --neutral-100: #e2e8f0;
+    --neutral-200: #cbd5e1;
+    --neutral-300: #94a3b8;
+    --neutral-400: #64748b;
+    --neutral-500: #475569;
+    --neutral-600: #334155;
+    --neutral-700: #1e293b;
+    --neutral-800: #0f172a;
+    --neutral-900: #020617;
+
+    --bg-primary: #0b0f17;
+    --bg-secondary: #11151f;
+    --bg-tertiary: #161b27;
+    --surface-1: #11151f;
+    --surface-2: #161b27;
+    --surface-3: #1c2230;
+    --surface-raised: #1a1f2c;
+
+    --text-primary: #f1f5f9;
+    --text-secondary: #b8c0cc;
+    --text-muted: #8a93a3;
+    --text-on-accent: #ffffff;
+
+    --border-color: #232a38;
+    --border-strong: #2e3647;
+
     --accent-primary: #60a5fa;
     --accent-secondary: #3b82f6;
-    --border-color: #30363d;
-    /* Subtle gradient for depth */
-    --card-bg: linear-gradient(145deg, #161b22, #0f1117);
-    --card-shadow: 0 4px 12px rgba(0, 0, 0, 0.5), 0 1px 3px rgba(0, 0, 0, 0.3);
-    /* Error and success states with better contrast */
-    --error-bg: #3c1a1e;
-    --error-text: #fca5a5;
-    --success-bg: #1c4532;
-    --success-text: #86efac;
-    /* Code blocks with better readability */
-    --code-bg: #21262d;
-    --code-text: #ffffff;
-    /* Header with slight transparency */
-    --header-bg: rgba(15, 17, 23, 0.95);
-    /* Buttons with vibrant gradients */
-    --button-bg: linear-gradient(135deg, #60a5fa, #3b82f6);
-    --button-text: #ffffff;
-    --button-hover: linear-gradient(135deg, #3b82f6, #2563eb);
-    /* Form elements */
-    --input-bg: #21262d;
-    --input-border-focus: rgba(96, 165, 250, 0.4);
-    /* Primary theme color */
-    --primary-color: #60a5fa;
+    --accent-strong: #2563eb;
+    --accent-soft: rgba(96, 165, 250, 0.22);
+    --accent-bg: rgba(96, 165, 250, 0.10);
+    --primary-color: var(--accent-primary);
     --primary-color-rgb: 96, 165, 250;
-    /* Scrollbar styling */
-    --scrollbar-track: #161b22;
-    --scrollbar-thumb: #30363d;
-    --scrollbar-thumb-hover: #4a5568;
-    /* Selection styling */
-    --selection-bg: rgba(96, 165, 250, 0.3);
+
+    --success: #22c55e;
+    --success-bg: rgba(34, 197, 94, 0.12);
+    --success-text: #86efac;
+    --warning: #f59e0b;
+    --warning-bg: rgba(245, 158, 11, 0.12);
+    --warning-text: #fcd34d;
+    --danger: #ef4444;
+    --error-bg: rgba(239, 68, 68, 0.12);
+    --error-text: #fca5a5;
+    --info: #38bdf8;
+    --info-bg: rgba(56, 189, 248, 0.12);
+    --info-text: #7dd3fc;
+
+    /* Category accents tweaked for dark mode */
+    --cat-text: #fb923c;
+    --cat-encoding: #34d399;
+    --cat-data: #818cf8;
+    --cat-web: #22d3ee;
+    --cat-crypto: #f87171;
+    --cat-time: #fbbf24;
+    --cat-visual: #f472b6;
+    --cat-api: #a78bfa;
+    --cat-network: #2dd4bf;
+    --cat-other: #64748b;
+
+    --input-bg: #161b27;
+    --input-border: #2a3142;
+    --input-border-hover: #3a4356;
+    --input-border-focus: var(--accent-primary);
+
+    --button-bg: var(--accent-primary);
+    --button-bg-hover: var(--accent-secondary);
+    --button-text: #0b0f17;
+    --button-hover: var(--accent-secondary);
+
+    --code-bg: #161b27;
+    --code-text: #e6edf6;
+
+    --header-bg: rgba(11, 15, 23, 0.85);
+    --header-border: #1f2533;
+    --sidebar-bg: #11151f;
+    --sidebar-border: #1f2533;
+
+    --scrollbar-track: transparent;
+    --scrollbar-thumb: #2a3142;
+    --scrollbar-thumb-hover: #3a4356;
+
+    --selection-bg: rgba(96, 165, 250, 0.32);
     --selection-text: #ffffff;
 }
 
-/* Theme Application */
+/* ============================================================
+   Base theme application
+   ============================================================ */
+
 body {
     background-color: var(--bg-primary);
     color: var(--text-primary);
-    transition: background-color 0.3s ease, color 0.3s ease;
 }
 
-/* Selection styling */
-::selection {
-    background-color: var(--selection-bg);
-    color: var(--selection-text);
-}
-
-/* Scrollbar styling */
-::-webkit-scrollbar {
-    width: 10px;
-    height: 10px;
-}
-
-::-webkit-scrollbar-track {
-    background: var(--scrollbar-track);
-}
-
-::-webkit-scrollbar-thumb {
-    background: var(--scrollbar-thumb);
-    border-radius: 5px;
-}
-
-::-webkit-scrollbar-thumb:hover {
-    background: var(--scrollbar-thumb-hover);
-}
-
-header {
-    background-color: var(--header-bg);
-    backdrop-filter: blur(10px);
-    border-bottom: 1px solid var(--border-color);
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
-    transition: background-color 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
-}
-
-[data-theme="dark"] header {
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.2);
-}
-
-.logo a {
+a {
     color: var(--accent-primary);
 }
 
-nav a {
-    color: var(--text-primary);
-}
-
-nav a:hover, nav a.active {
-    color: var(--accent-primary);
-}
-
-.theme-toggle button {
-    color: var(--text-primary);
-}
-
-.theme-toggle .light-icon {
-    display: none;
-}
-
-.theme-toggle .dark-icon {
-    display: block;
-}
-
-[data-theme="dark"] .theme-toggle .light-icon {
-    display: block;
-}
-
-[data-theme="dark"] .theme-toggle .dark-icon {
-    display: none;
-}
-
-.tool-card {
-    background: var(--card-bg);
-    box-shadow: var(--card-shadow);
-    border: 1px solid var(--border-color);
-    transition: transform 0.3s ease, box-shadow 0.3s ease, background 0.3s ease, border-color 0.3s ease;
-}
-
-.tool-card:hover {
-    box-shadow: 0 12px 20px rgba(0, 0, 0, 0.1), 0 4px 8px rgba(0, 0, 0, 0.05);
-}
-
-[data-theme="dark"] .tool-card:hover {
-    box-shadow: 0 12px 20px rgba(0, 0, 0, 0.4), 0 4px 8px rgba(0, 0, 0, 0.2);
-}
-
-.tool-card h3 {
-    color: var(--accent-primary);
-}
-
-footer {
-    border-top: 1px solid var(--border-color);
-    background-color: var(--bg-secondary);
-    transition: background-color 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
-}
-
-[data-theme="dark"] footer {
-    background: linear-gradient(180deg, var(--bg-primary) 0%, var(--bg-secondary) 100%);
-    box-shadow: 0 -4px 6px rgba(0, 0, 0, 0.1);
-}
-
-footer a, .credits a {
-    color: var(--accent-primary);
-    transition: color 0.3s ease, text-decoration 0.3s ease;
-}
-
-footer a:hover, .credits a:hover {
+a:hover {
     color: var(--accent-secondary);
 }
 
-.credits a {
-    font-weight: 600;
-    position: relative;
-    text-decoration: none;
+hr {
+    border: 0;
+    border-top: 1px solid var(--border-color);
+    margin: var(--space-6) 0;
 }
 
-.credits a::after {
-    content: '';
-    position: absolute;
-    width: 100%;
-    height: 1px;
-    bottom: 0;
-    left: 0;
-    background-color: var(--accent-primary);
-    transform: scaleX(0);
-    transform-origin: bottom right;
-    transition: transform 0.3s ease;
-}
-
-.credits a:hover::after {
-    transform: scaleX(1);
-    transform-origin: bottom left;
-}
-
-[data-theme="dark"] .credits a {
-    color: var(--accent-primary);
-}
-
-[data-theme="dark"] .credits a::after {
-    background-color: var(--accent-secondary);
-}
-
-textarea, input[type="text"], select {
+/* Form element theming */
+textarea, input[type="text"], input[type="number"], input[type="search"],
+input[type="password"], input[type="email"], input[type="url"], select {
     background-color: var(--input-bg);
-    border: 1px solid var(--border-color);
+    border: 1px solid var(--input-border);
     color: var(--text-primary);
-    transition: border-color 0.3s ease, box-shadow 0.3s ease;
+    border-radius: var(--radius-md);
+    padding: var(--space-2) var(--space-3);
+    transition: border-color var(--duration-fast) var(--ease-out),
+                box-shadow var(--duration-fast) var(--ease-out);
 }
 
-textarea:focus, input[type="text"]:focus, select:focus {
-    border-color: var(--accent-primary);
-    box-shadow: 0 0 0 3px var(--input-border-focus);
+textarea:hover, input[type="text"]:hover, input[type="number"]:hover,
+input[type="search"]:hover, input[type="password"]:hover,
+input[type="email"]:hover, input[type="url"]:hover, select:hover {
+    border-color: var(--input-border-hover);
+}
+
+textarea:focus, input[type="text"]:focus, input[type="number"]:focus,
+input[type="search"]:focus, input[type="password"]:focus,
+input[type="email"]:focus, input[type="url"]:focus, select:focus {
+    border-color: var(--input-border-focus);
+    box-shadow: var(--focus-ring);
     outline: none;
 }
 
-button.primary {
-    background: var(--button-bg);
-    color: var(--button-text);
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-    transition: background 0.3s ease, transform 0.2s ease, box-shadow 0.3s ease;
-}
-
-button.primary:hover {
-    background: var(--button-hover);
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
-    transform: translateY(-1px);
-}
-
-[data-theme="dark"] button.primary {
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
-}
-
-[data-theme="dark"] button.primary:hover {
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.4);
-}
-
-button.secondary {
-    background-color: var(--bg-tertiary);
-    color: var(--text-primary);
-    border: 1px solid var(--border-color);
-}
-
-button.secondary:hover {
-    background-color: var(--bg-secondary);
-}
-
-.error-message {
-    background-color: var(--error-bg);
-    color: var(--error-text);
-    border: 1px solid var(--error-text);
-}
-
-.success-message {
-    background-color: var(--success-bg);
-    color: var(--success-text);
-    border: 1px solid var(--success-text);
+textarea {
+    font-family: var(--font-mono);
+    line-height: var(--leading-normal);
+    resize: vertical;
+    min-height: 150px;
+    padding: var(--space-3);
 }
 
 pre, code {
     background-color: var(--code-bg);
     color: var(--code-text);
-    border: 1px solid var(--border-color);
-    border-radius: var(--border-radius);
-    padding: var(--spacing-xs);
+    border-radius: var(--radius-sm);
     font-family: var(--font-mono);
-    transition: background-color 0.3s ease, color 0.3s ease, border-color 0.3s ease;
 }
 
-.hero p {
-    font-size: 1.2rem;
-    max-width: 600px;
-    margin: 0 auto;
+code {
+    padding: 0.1em 0.4em;
+    font-size: 0.9em;
 }
 
-[data-theme="dark"] .hero p {
-    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
+pre {
+    padding: var(--space-4);
+    overflow: auto;
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
 }
 
-.hero h1 {
-    font-size: 3rem;
-    margin-bottom: var(--spacing-md);
-    background: linear-gradient(to right, var(--accent-primary), var(--accent-secondary));
-    -webkit-background-clip: text;
-    background-clip: text;
-    color: transparent;
-    display: inline-block;
-    font-weight: 700;
-}
-
-[data-theme="dark"] .hero h1 {
-    text-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
-    background: linear-gradient(to right, var(--accent-primary), var(--text-primary));
-    -webkit-background-clip: text;
-    background-clip: text;
-    color: transparent;
-    display: inline-block;
-    font-weight: 700;
-}
-
-.credits {
-    margin-top: var(--spacing-md);
-    font-size: 0.9rem;
-}
-
-.credits p {
-    font-size: 0.9rem;
-    opacity: 0.9;
-}
-
-[data-theme="dark"] .credits p {
-    opacity: 1;
+pre code {
+    padding: 0;
+    background: transparent;
+    border-radius: 0;
+    font-size: inherit;
 }

--- a/index.html
+++ b/index.html
@@ -4,251 +4,398 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Devtools - A comprehensive collection of web-based tools for developers">
-    <title>Devtools - Developer Tools</title>
+    <meta name="theme-color" content="#0b0f17">
+    <title>Devtools — Developer Tools</title>
     <link rel="stylesheet" href="css/styles.css">
     <link rel="stylesheet" href="css/theme.css">
+    <link rel="stylesheet" href="css/layout.css">
+    <link rel="stylesheet" href="css/components.css">
     <link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="assets/favicon-32x32.png" type="image/png" sizes="32x32">
     <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <!-- Open Graph / Social Media Meta Tags -->
-    <meta property="og:title" content="Devtools - Developer Tools">
+    <meta property="og:title" content="Devtools — Developer Tools">
     <meta property="og:description" content="A comprehensive collection of web-based tools for developers">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://irfansofyana.github.io/Devtools/">
 </head>
 <body>
-    <header>
-        <div class="container">
-            <div class="logo">
-                <a href="index.html"><i class="fas fa-tools"></i> Devtools</a>
+    <a class="skip-link" href="#main-content">Skip to content</a>
+
+    <div class="app-shell">
+        <aside class="sidebar" id="sidebar" aria-label="Primary navigation">
+            <a class="sidebar__brand" href="index.html">
+                <span class="sidebar__brand-mark" aria-hidden="true">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg>
+                </span>
+                Devtools
+            </a>
+
+            <div class="sidebar__section">
+                <div class="sidebar__heading">Browse</div>
+                <nav class="sidebar__nav" id="category-nav" aria-label="Categories">
+                    <!-- Populated by js/search.js -->
+                </nav>
             </div>
-            <nav>
-                <ul>
-                    <li><a href="index.html" class="active">Home</a></li>
-                    <li><a href="https://github.com/irfansofyana/Devtools" target="_blank">GitHub</a></li>
-                </ul>
-            </nav>
-            <div class="theme-toggle">
-                <button id="theme-toggle-btn" aria-label="Toggle dark/light theme">
-                    <span class="icon light-icon">☀️</span>
-                    <span class="icon dark-icon">🌙</span>
+
+            <div class="sidebar__footer">
+                <div class="sidebar__footer-links">
+                    <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+                        <i class="fab fa-github" aria-hidden="true"></i>
+                    </a>
+                    <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools/issues" target="_blank" rel="noopener" aria-label="Report an issue">
+                        <i class="fas fa-comment-dots" aria-hidden="true"></i>
+                    </a>
+                </div>
+                <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
+                    <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+                    <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
                 </button>
             </div>
-        </div>
-    </header>
+        </aside>
 
-    <main>
-        <section class="hero">
-            <div class="container">
-                <h1>Developer Tools</h1>
-                <p>A simple collection of web-based tools for developers</p>
-                <div class="credits">
-                    <p>Built by <a href="https://github.com/irfansofyana" target="_blank">irfansofyana</a> | Vibing with <a href="https://windsurf.com/" target="_blank">Windsurf</a></p>
+        <div class="sidebar-scrim" id="sidebar-scrim" aria-hidden="true"></div>
+
+        <div class="app-main">
+            <header class="top-bar">
+                <button class="top-bar__menu-btn" id="sidebar-toggle" aria-label="Open menu" aria-controls="sidebar" aria-expanded="false">
+                    <i class="fas fa-bars" aria-hidden="true"></i>
+                </button>
+                <div class="top-bar__title">All Tools</div>
+                <div class="top-bar__search">
+                    <i class="fas fa-search top-bar__search-icon" aria-hidden="true"></i>
+                    <input type="search" id="tool-search" class="top-bar__search-input" placeholder="Search tools…" aria-label="Search tools" autocomplete="off">
+                    <button type="button" id="search-clear" class="top-bar__search-clear hidden" aria-label="Clear search">
+                        <i class="fas fa-times" aria-hidden="true"></i>
+                    </button>
+                    <span class="top-bar__search-kbd"><kbd class="kbd">⌘</kbd> <kbd class="kbd">K</kbd></span>
                 </div>
-            </div>
-        </section>
+                <div class="top-bar__actions"></div>
+            </header>
 
-        <section class="tools">
-            <div class="container">
-                <h2>Available Tools</h2>
-                <!-- Search and filter will be inserted here by JavaScript -->
-                <div class="tools-grid" id="tools-grid">
-                    <a href="tools/api-mock-generator.html" class="tool-card">
-                        <div class="tool-icon"><i class="fas fa-vial"></i></div>
-                        <h3>API Mock Data Generator</h3>
-                        <p>Generate realistic mock data for API testing</p>
-                    </a>
-                    <a href="tools/ascii-art-generator.html" class="tool-card">
-                        <div class="tool-icon"><i class="fas fa-font"></i></div>
-                        <h3>ASCII Art Generator</h3>
-                        <p>Generate ASCII art from text with multiple fonts and styles</p>
-                    </a>
-                    <a href="tools/ascii-hex-converter.html" class="tool-card">
-                        <div class="tool-icon"><i class="fas fa-exchange-alt"></i></div>
-                        <h3>ASCII <> HEX Converter</h3>
-                        <p>Convert between ASCII text and hexadecimal representation</p>
-                    </a>
-                    <a href="tools/backslash-escape-unescape.html" class="tool-card">
-                        <div class="tool-icon"><i class="fas fa-backspace"></i></div>
-                        <h3>Backslash Escape/Unescape</h3>
-                        <p>Escape and unescape backslashes in text</p>
-                    </a>
-                    <a href="tools/base64-encoder-decoder.html" class="tool-card">
-                        <div class="tool-icon"><i class="fas fa-exchange-alt"></i></div>
-                        <h3>Base64 Encoder/Decoder</h3>
-                        <p>Encode and decode text or files using Base64 encoding</p>
-                    </a>
-                    <a href="tools/color-converter.html" class="tool-card">
-                        <div class="tool-icon"><i class="fas fa-palette"></i></div>
-                        <h3>Color Converter</h3>
-                        <p>Convert between HEX, RGB, and HSL color formats</p>
-                    </a>
-                    <a href="tools/crontab-generator.html" class="tool-card">
-                        <div class="tool-icon"><i class="fas fa-clock"></i></div>
-                        <h3>Crontab Generator</h3>
-                        <p>Create crontab expressions visually with human-readable descriptions</p>
-                    </a>
-                    <a href="tools/csv-json-converter.html" class="tool-card">
-                        <div class="tool-icon"><i class="fas fa-file-code"></i></div>
-                        <h3>CSV <> JSON Converter</h3>
-                        <p>Convert between CSV and JSON data formats</p>
-                    </a>
-                    <a href="tools/csv-visualizer.html" class="tool-card">
-                        <div class="tool-icon"><i class="fas fa-table"></i></div>
-                        <h3>CSV Visualizer</h3>
-                        <p>Visualize CSV data as HTML tables with export options</p>
-                    </a>
-                    <a href="tools/curl-constructor.html" class="tool-card">
-                        <div class="tool-icon"><i class="fas fa-terminal"></i></div>
-                        <h3>CURL Constructor</h3>
-                        <p>Build CURL commands for terminal execution with customizable options</p>
-                    </a>
-                    <a href="tools/hash-generator.html" class="tool-card">
-                        <div class="tool-icon"><i class="fas fa-hashtag"></i></div>
-                        <h3>Hash Generator</h3>
-                        <p>Generate MD5, SHA-1, SHA-256, and SHA-512 hashes</p>
-                    </a>
-                    <a href="tools/json-formatter.html" class="tool-card">
-                        <div class="tool-icon"><i class="fas fa-code"></i></div>
-                        <h3>JSON Beautifier/Minifier</h3>
-                        <p>Format and compress JSON with syntax highlighting</p>
-                    </a>
-                    <a href="tools/json-to-protobuf.html" class="tool-card">
-                        <div class="tool-icon"><i class="fas fa-cube"></i></div>
-                        <h3>JSON to Protobuf</h3>
-                        <p>Generate Protocol Buffer definitions from JSON examples</p>
-                    </a>
-                    <a href="tools/json-yaml-explorer.html" class="tool-card">
-                        <div class="tool-icon"><i class="fas fa-project-diagram"></i></div>
-                        <h3>JSON/YAML Explorer</h3>
-                        <p>Visualize and explore JSON and YAML data with interactive tree view</p>
-                    </a>
-                    <a href="tools/json-yaml-converter.html" class="tool-card">
-                        <div class="tool-icon"><i class="fas fa-sync-alt"></i></div>
-                        <h3>JSON <-> YAML Converter</h3>
-                        <p>Convert between JSON and YAML formats with validation</p>
-                    </a>
-                    <a href="tools/jwt-decoder.html" class="tool-card">
-                        <div class="tool-icon"><i class="fas fa-key"></i></div>
-                        <h3>JWT Decoder</h3>
-                        <p>Decode and inspect JSON Web Tokens (JWT)</p>
-                    </a>
-                    <a href="tools/line-sort-dedupe.html" class="tool-card">
-                        <div class="tool-icon"><i class="fas fa-sort-alpha-down"></i></div>
-                        <h3>Line Sort/Dedupe</h3>
-                        <p>Sort lines alphabetically and remove duplicates</p>
-                    </a>
-                    <a href="tools/markdown-preview.html" class="tool-card">
-                        <div class="tool-icon"><i class="fab fa-markdown"></i></div>
-                        <h3>Markdown Preview</h3>
-                        <p>Preview Markdown with live rendering</p>
-                    </a>
-                    <a href="tools/mermaid-diagram-editor.html" class="tool-card">
-                        <div class="tool-icon"><i class="fas fa-project-diagram"></i></div>
-                        <h3>Mermaid Diagram Editor</h3>
-                        <p>Create diagrams with Mermaid syntax and live preview</p>
-                    </a>
-                    <a href="tools/ocr-tool.html" class="tool-card">
-                        <div class="tool-icon"><i class="fas fa-eye"></i></div>
-                        <h3>OCR Tool</h3>
-                        <p>Extract text from images and PDFs using offline OCR</p>
-                    </a>
-                    <a href="tools/qr-code-tool.html" class="tool-card">
-                        <div class="tool-icon"><i class="fas fa-qrcode"></i></div>
-                        <h3>QR Code Reader/Generator</h3>
-                        <p>Generate QR codes from text or URLs, and scan QR codes from images</p>
-                    </a>
-                    <a href="tools/password-generator.html" class="tool-card">
-                        <div class="tool-icon"><i class="fas fa-lock"></i></div>
-                        <h3>Random Password Generator</h3>
-                        <p>Generate secure random passwords with customizable options</p>
-                    </a>
-                    <a href="tools/string-generator.html" class="tool-card">
-                        <div class="tool-icon"><i class="fas fa-random"></i></div>
-                        <h3>Random String Generator</h3>
-                        <p>Generate random strings with patterns and custom options</p>
-                    </a>
-                    <a href="tools/secret-share.html" class="tool-card">
-                        <div class="tool-icon"><i class="fas fa-user-secret"></i></div>
-                        <h3>Secret Share</h3>
-                        <p>Securely share encrypted messages with password protection</p>
-                    </a>
-                    <a href="tools/regex-tester.html" class="tool-card">
-                        <div class="tool-icon"><i class="fas fa-search"></i></div>
-                        <h3>Regular Expression Tester</h3>
-                        <p>Test and validate regular expressions with live results</p>
-                    </a>
-                    <a href="tools/string-case-converter.html" class="tool-card">
-                        <div class="tool-icon"><i class="fas fa-font"></i></div>
-                        <h3>String Case Converter</h3>
-                        <p>Convert between camelCase, snake_case, kebab-case and more</p>
-                    </a>
-                    <a href="tools/text-diff.html" class="tool-card">
-                        <div class="tool-icon"><i class="fas fa-columns"></i></div>
-                        <h3>Text Diff Utility</h3>
-                        <p>Compare two text blocks and highlight differences</p>
-                    </a>
-                    <a href="tools/timestamp-converter.html" class="tool-card">
-                        <div class="tool-icon"><i class="fas fa-calendar-alt"></i></div>
-                        <h3>Timestamp Converter</h3>
-                        <p>Convert between various timestamp formats and human-readable dates</p>
-                    </a>
-                    <a href="tools/url-encoder-decoder.html" class="tool-card">
-                        <div class="tool-icon"><i class="fas fa-link"></i></div>
-                        <h3>URL Encoder/Decoder</h3>
-                        <p>Encode and decode URLs and URL components</p>
-                    </a>
-                    <a href="tools/url-parser.html" class="tool-card">
-                        <div class="tool-icon"><i class="fas fa-sitemap"></i></div>
-                        <h3>URL Parser</h3>
-                        <p>Parse and extract components from URLs</p>
-                    </a>
-                    <a href="tools/url-to-markdown.html" class="tool-card">
-                        <div class="tool-icon"><i class="fas fa-file-alt"></i></div>
-                        <h3>URL to Markdown</h3>
-                        <p>Scrape URL content and convert to Markdown format</p>
-                    </a>
-                    <a href="tools/uuid-generator.html" class="tool-card">
-                        <div class="tool-icon"><i class="fas fa-fingerprint"></i></div>
-                        <h3>UUID Generator</h3>
-                        <p>Generate random UUIDs in version 4 format</p>
-                    </a>
-                    <a href="tools/vim-editor.html" class="tool-card">
-                        <div class="tool-icon"><i class="fas fa-keyboard"></i></div>
-                        <h3>Vim-Style Code Editor</h3>
-                        <p>Browser-based text editor with Vim key bindings</p>
-                    </a>
-                    <a href="tools/ip-lookup.html" class="tool-card">
-                        <div class="tool-icon"><i class="fas fa-globe"></i></div>
-                        <h3>IP Address Lookup</h3>
-                        <p>Get detailed information about any IP address including geolocation, ISP, and network details</p>
-                    </a>
-                    <a href="tools/ssl-checker.html" class="tool-card">
-                        <div class="tool-icon"><i class="fas fa-shield-alt"></i></div>
-                        <h3>SSL/TLS Certificate Checker</h3>
-                        <p>Analyze SSL/TLS certificates for any domain and check their security status</p>
-                    </a>
-                    <a href="tools/subnet-calculator.html" class="tool-card">
-                        <div class="tool-icon"><i class="fas fa-network-wired"></i></div>
-                        <h3>Subnet Calculator</h3>
-                        <p>Calculate subnet information, IP ranges, and network details from CIDR notation</p>
-                    </a>
+            <main class="content" id="main-content">
+                <div class="content__inner">
+                    <section class="hero-strip">
+                        <div>
+                            <h1 class="hero-strip__title">Developer Tools</h1>
+                            <p class="hero-strip__subtitle">A collection of fast, offline-friendly utilities for everyday developer tasks.</p>
+                        </div>
+                        <div class="hero-strip__meta">
+                            <span id="tool-count">36 tools</span> · Built by
+                            <a href="https://github.com/irfansofyana" target="_blank" rel="noopener">irfansofyana</a>
+                        </div>
+                    </section>
 
+                    <div class="tool-grid" id="tools-grid">
+                        <a href="tools/api-mock-generator.html" class="tool-card" data-category="api">
+                            <div class="tool-card__icon"><i class="fas fa-vial" aria-hidden="true"></i></div>
+                            <div class="tool-card__body">
+                                <h3 class="tool-card__title">API Mock Data Generator</h3>
+                                <p class="tool-card__desc">Generate realistic mock data for API testing</p>
+                                <span class="chip tool-card__chip" data-category="api">API</span>
+                            </div>
+                        </a>
+                        <a href="tools/ascii-art-generator.html" class="tool-card" data-category="visual">
+                            <div class="tool-card__icon"><i class="fas fa-font" aria-hidden="true"></i></div>
+                            <div class="tool-card__body">
+                                <h3 class="tool-card__title">ASCII Art Generator</h3>
+                                <p class="tool-card__desc">Generate ASCII art from text with multiple fonts and styles</p>
+                                <span class="chip tool-card__chip" data-category="visual">Visual</span>
+                            </div>
+                        </a>
+                        <a href="tools/ascii-hex-converter.html" class="tool-card" data-category="encoding">
+                            <div class="tool-card__icon"><i class="fas fa-exchange-alt" aria-hidden="true"></i></div>
+                            <div class="tool-card__body">
+                                <h3 class="tool-card__title">ASCII ⇄ HEX Converter</h3>
+                                <p class="tool-card__desc">Convert between ASCII text and hexadecimal representation</p>
+                                <span class="chip tool-card__chip" data-category="encoding">Encoding</span>
+                            </div>
+                        </a>
+                        <a href="tools/backslash-escape-unescape.html" class="tool-card" data-category="text">
+                            <div class="tool-card__icon"><i class="fas fa-backspace" aria-hidden="true"></i></div>
+                            <div class="tool-card__body">
+                                <h3 class="tool-card__title">Backslash Escape/Unescape</h3>
+                                <p class="tool-card__desc">Escape and unescape backslashes in text</p>
+                                <span class="chip tool-card__chip" data-category="text">Text</span>
+                            </div>
+                        </a>
+                        <a href="tools/base64-encoder-decoder.html" class="tool-card" data-category="encoding">
+                            <div class="tool-card__icon"><i class="fas fa-exchange-alt" aria-hidden="true"></i></div>
+                            <div class="tool-card__body">
+                                <h3 class="tool-card__title">Base64 Encoder/Decoder</h3>
+                                <p class="tool-card__desc">Encode and decode text or files using Base64 encoding</p>
+                                <span class="chip tool-card__chip" data-category="encoding">Encoding</span>
+                            </div>
+                        </a>
+                        <a href="tools/color-converter.html" class="tool-card" data-category="visual">
+                            <div class="tool-card__icon"><i class="fas fa-palette" aria-hidden="true"></i></div>
+                            <div class="tool-card__body">
+                                <h3 class="tool-card__title">Color Converter</h3>
+                                <p class="tool-card__desc">Convert between HEX, RGB, and HSL color formats</p>
+                                <span class="chip tool-card__chip" data-category="visual">Visual</span>
+                            </div>
+                        </a>
+                        <a href="tools/crontab-generator.html" class="tool-card" data-category="time">
+                            <div class="tool-card__icon"><i class="fas fa-clock" aria-hidden="true"></i></div>
+                            <div class="tool-card__body">
+                                <h3 class="tool-card__title">Crontab Generator</h3>
+                                <p class="tool-card__desc">Create crontab expressions visually with human-readable descriptions</p>
+                                <span class="chip tool-card__chip" data-category="time">Time</span>
+                            </div>
+                        </a>
+                        <a href="tools/csv-json-converter.html" class="tool-card" data-category="data format">
+                            <div class="tool-card__icon"><i class="fas fa-file-code" aria-hidden="true"></i></div>
+                            <div class="tool-card__body">
+                                <h3 class="tool-card__title">CSV ⇄ JSON Converter</h3>
+                                <p class="tool-card__desc">Convert between CSV and JSON data formats</p>
+                                <span class="chip tool-card__chip" data-category="data format">Data</span>
+                            </div>
+                        </a>
+                        <a href="tools/csv-visualizer.html" class="tool-card" data-category="data format">
+                            <div class="tool-card__icon"><i class="fas fa-table" aria-hidden="true"></i></div>
+                            <div class="tool-card__body">
+                                <h3 class="tool-card__title">CSV Visualizer</h3>
+                                <p class="tool-card__desc">Visualize CSV data as HTML tables with export options</p>
+                                <span class="chip tool-card__chip" data-category="data format">Data</span>
+                            </div>
+                        </a>
+                        <a href="tools/curl-constructor.html" class="tool-card" data-category="web">
+                            <div class="tool-card__icon"><i class="fas fa-terminal" aria-hidden="true"></i></div>
+                            <div class="tool-card__body">
+                                <h3 class="tool-card__title">CURL Constructor</h3>
+                                <p class="tool-card__desc">Build CURL commands for terminal execution with customizable options</p>
+                                <span class="chip tool-card__chip" data-category="web">Web</span>
+                            </div>
+                        </a>
+                        <a href="tools/hash-generator.html" class="tool-card" data-category="crypto">
+                            <div class="tool-card__icon"><i class="fas fa-hashtag" aria-hidden="true"></i></div>
+                            <div class="tool-card__body">
+                                <h3 class="tool-card__title">Hash Generator</h3>
+                                <p class="tool-card__desc">Generate MD5, SHA-1, SHA-256, and SHA-512 hashes</p>
+                                <span class="chip tool-card__chip" data-category="crypto">Crypto</span>
+                            </div>
+                        </a>
+                        <a href="tools/json-formatter.html" class="tool-card" data-category="data format">
+                            <div class="tool-card__icon"><i class="fas fa-code" aria-hidden="true"></i></div>
+                            <div class="tool-card__body">
+                                <h3 class="tool-card__title">JSON Beautifier/Minifier</h3>
+                                <p class="tool-card__desc">Format and compress JSON with syntax highlighting</p>
+                                <span class="chip tool-card__chip" data-category="data format">Data</span>
+                            </div>
+                        </a>
+                        <a href="tools/json-to-protobuf.html" class="tool-card" data-category="data format">
+                            <div class="tool-card__icon"><i class="fas fa-cube" aria-hidden="true"></i></div>
+                            <div class="tool-card__body">
+                                <h3 class="tool-card__title">JSON to Protobuf</h3>
+                                <p class="tool-card__desc">Generate Protocol Buffer definitions from JSON examples</p>
+                                <span class="chip tool-card__chip" data-category="data format">Data</span>
+                            </div>
+                        </a>
+                        <a href="tools/json-yaml-explorer.html" class="tool-card" data-category="data format">
+                            <div class="tool-card__icon"><i class="fas fa-project-diagram" aria-hidden="true"></i></div>
+                            <div class="tool-card__body">
+                                <h3 class="tool-card__title">JSON/YAML Explorer</h3>
+                                <p class="tool-card__desc">Visualize and explore JSON and YAML data with interactive tree view</p>
+                                <span class="chip tool-card__chip" data-category="data format">Data</span>
+                            </div>
+                        </a>
+                        <a href="tools/json-yaml-converter.html" class="tool-card" data-category="data format">
+                            <div class="tool-card__icon"><i class="fas fa-sync-alt" aria-hidden="true"></i></div>
+                            <div class="tool-card__body">
+                                <h3 class="tool-card__title">JSON ⇄ YAML Converter</h3>
+                                <p class="tool-card__desc">Convert between JSON and YAML formats with validation</p>
+                                <span class="chip tool-card__chip" data-category="data format">Data</span>
+                            </div>
+                        </a>
+                        <a href="tools/jwt-decoder.html" class="tool-card" data-category="web">
+                            <div class="tool-card__icon"><i class="fas fa-key" aria-hidden="true"></i></div>
+                            <div class="tool-card__body">
+                                <h3 class="tool-card__title">JWT Decoder</h3>
+                                <p class="tool-card__desc">Decode and inspect JSON Web Tokens (JWT)</p>
+                                <span class="chip tool-card__chip" data-category="web">Web</span>
+                            </div>
+                        </a>
+                        <a href="tools/line-sort-dedupe.html" class="tool-card" data-category="text">
+                            <div class="tool-card__icon"><i class="fas fa-sort-alpha-down" aria-hidden="true"></i></div>
+                            <div class="tool-card__body">
+                                <h3 class="tool-card__title">Line Sort/Dedupe</h3>
+                                <p class="tool-card__desc">Sort lines alphabetically and remove duplicates</p>
+                                <span class="chip tool-card__chip" data-category="text">Text</span>
+                            </div>
+                        </a>
+                        <a href="tools/markdown-preview.html" class="tool-card" data-category="visual">
+                            <div class="tool-card__icon"><i class="fab fa-markdown" aria-hidden="true"></i></div>
+                            <div class="tool-card__body">
+                                <h3 class="tool-card__title">Markdown Preview</h3>
+                                <p class="tool-card__desc">Preview Markdown with live rendering</p>
+                                <span class="chip tool-card__chip" data-category="visual">Visual</span>
+                            </div>
+                        </a>
+                        <a href="tools/mermaid-diagram-editor.html" class="tool-card" data-category="visual">
+                            <div class="tool-card__icon"><i class="fas fa-project-diagram" aria-hidden="true"></i></div>
+                            <div class="tool-card__body">
+                                <h3 class="tool-card__title">Mermaid Diagram Editor</h3>
+                                <p class="tool-card__desc">Create diagrams with Mermaid syntax and live preview</p>
+                                <span class="chip tool-card__chip" data-category="visual">Visual</span>
+                            </div>
+                        </a>
+                        <a href="tools/ocr-tool.html" class="tool-card" data-category="visual">
+                            <div class="tool-card__icon"><i class="fas fa-eye" aria-hidden="true"></i></div>
+                            <div class="tool-card__body">
+                                <h3 class="tool-card__title">OCR Tool</h3>
+                                <p class="tool-card__desc">Extract text from images and PDFs using offline OCR</p>
+                                <span class="chip tool-card__chip" data-category="visual">Visual</span>
+                            </div>
+                        </a>
+                        <a href="tools/qr-code-tool.html" class="tool-card" data-category="visual">
+                            <div class="tool-card__icon"><i class="fas fa-qrcode" aria-hidden="true"></i></div>
+                            <div class="tool-card__body">
+                                <h3 class="tool-card__title">QR Code Reader/Generator</h3>
+                                <p class="tool-card__desc">Generate QR codes from text or URLs, and scan QR codes from images</p>
+                                <span class="chip tool-card__chip" data-category="visual">Visual</span>
+                            </div>
+                        </a>
+                        <a href="tools/password-generator.html" class="tool-card" data-category="crypto">
+                            <div class="tool-card__icon"><i class="fas fa-lock" aria-hidden="true"></i></div>
+                            <div class="tool-card__body">
+                                <h3 class="tool-card__title">Random Password Generator</h3>
+                                <p class="tool-card__desc">Generate secure random passwords with customizable options</p>
+                                <span class="chip tool-card__chip" data-category="crypto">Crypto</span>
+                            </div>
+                        </a>
+                        <a href="tools/string-generator.html" class="tool-card" data-category="text">
+                            <div class="tool-card__icon"><i class="fas fa-random" aria-hidden="true"></i></div>
+                            <div class="tool-card__body">
+                                <h3 class="tool-card__title">Random String Generator</h3>
+                                <p class="tool-card__desc">Generate random strings with patterns and custom options</p>
+                                <span class="chip tool-card__chip" data-category="text">Text</span>
+                            </div>
+                        </a>
+                        <a href="tools/secret-share.html" class="tool-card" data-category="crypto">
+                            <div class="tool-card__icon"><i class="fas fa-user-secret" aria-hidden="true"></i></div>
+                            <div class="tool-card__body">
+                                <h3 class="tool-card__title">Secret Share</h3>
+                                <p class="tool-card__desc">Securely share encrypted messages with password protection</p>
+                                <span class="chip tool-card__chip" data-category="crypto">Crypto</span>
+                            </div>
+                        </a>
+                        <a href="tools/regex-tester.html" class="tool-card" data-category="api">
+                            <div class="tool-card__icon"><i class="fas fa-search" aria-hidden="true"></i></div>
+                            <div class="tool-card__body">
+                                <h3 class="tool-card__title">Regular Expression Tester</h3>
+                                <p class="tool-card__desc">Test and validate regular expressions with live results</p>
+                                <span class="chip tool-card__chip" data-category="api">API</span>
+                            </div>
+                        </a>
+                        <a href="tools/string-case-converter.html" class="tool-card" data-category="text">
+                            <div class="tool-card__icon"><i class="fas fa-font" aria-hidden="true"></i></div>
+                            <div class="tool-card__body">
+                                <h3 class="tool-card__title">String Case Converter</h3>
+                                <p class="tool-card__desc">Convert between camelCase, snake_case, kebab-case and more</p>
+                                <span class="chip tool-card__chip" data-category="text">Text</span>
+                            </div>
+                        </a>
+                        <a href="tools/text-diff.html" class="tool-card" data-category="text">
+                            <div class="tool-card__icon"><i class="fas fa-columns" aria-hidden="true"></i></div>
+                            <div class="tool-card__body">
+                                <h3 class="tool-card__title">Text Diff Utility</h3>
+                                <p class="tool-card__desc">Compare two text blocks and highlight differences</p>
+                                <span class="chip tool-card__chip" data-category="text">Text</span>
+                            </div>
+                        </a>
+                        <a href="tools/timestamp-converter.html" class="tool-card" data-category="time">
+                            <div class="tool-card__icon"><i class="fas fa-calendar-alt" aria-hidden="true"></i></div>
+                            <div class="tool-card__body">
+                                <h3 class="tool-card__title">Timestamp Converter</h3>
+                                <p class="tool-card__desc">Convert between various timestamp formats and human-readable dates</p>
+                                <span class="chip tool-card__chip" data-category="time">Time</span>
+                            </div>
+                        </a>
+                        <a href="tools/url-encoder-decoder.html" class="tool-card" data-category="encoding">
+                            <div class="tool-card__icon"><i class="fas fa-link" aria-hidden="true"></i></div>
+                            <div class="tool-card__body">
+                                <h3 class="tool-card__title">URL Encoder/Decoder</h3>
+                                <p class="tool-card__desc">Encode and decode URLs and URL components</p>
+                                <span class="chip tool-card__chip" data-category="encoding">Encoding</span>
+                            </div>
+                        </a>
+                        <a href="tools/url-parser.html" class="tool-card" data-category="web">
+                            <div class="tool-card__icon"><i class="fas fa-sitemap" aria-hidden="true"></i></div>
+                            <div class="tool-card__body">
+                                <h3 class="tool-card__title">URL Parser</h3>
+                                <p class="tool-card__desc">Parse and extract components from URLs</p>
+                                <span class="chip tool-card__chip" data-category="web">Web</span>
+                            </div>
+                        </a>
+                        <a href="tools/url-to-markdown.html" class="tool-card" data-category="web">
+                            <div class="tool-card__icon"><i class="fas fa-file-alt" aria-hidden="true"></i></div>
+                            <div class="tool-card__body">
+                                <h3 class="tool-card__title">URL to Markdown</h3>
+                                <p class="tool-card__desc">Scrape URL content and convert to Markdown format</p>
+                                <span class="chip tool-card__chip" data-category="web">Web</span>
+                            </div>
+                        </a>
+                        <a href="tools/uuid-generator.html" class="tool-card" data-category="crypto">
+                            <div class="tool-card__icon"><i class="fas fa-fingerprint" aria-hidden="true"></i></div>
+                            <div class="tool-card__body">
+                                <h3 class="tool-card__title">UUID Generator</h3>
+                                <p class="tool-card__desc">Generate random UUIDs in version 4 format</p>
+                                <span class="chip tool-card__chip" data-category="crypto">Crypto</span>
+                            </div>
+                        </a>
+                        <a href="tools/vim-editor.html" class="tool-card" data-category="text">
+                            <div class="tool-card__icon"><i class="fas fa-keyboard" aria-hidden="true"></i></div>
+                            <div class="tool-card__body">
+                                <h3 class="tool-card__title">Vim-Style Code Editor</h3>
+                                <p class="tool-card__desc">Browser-based text editor with Vim key bindings</p>
+                                <span class="chip tool-card__chip" data-category="text">Text</span>
+                            </div>
+                        </a>
+                        <a href="tools/ip-lookup.html" class="tool-card" data-category="network">
+                            <div class="tool-card__icon"><i class="fas fa-globe" aria-hidden="true"></i></div>
+                            <div class="tool-card__body">
+                                <h3 class="tool-card__title">IP Address Lookup</h3>
+                                <p class="tool-card__desc">Get detailed information about any IP address including geolocation, ISP, and network details</p>
+                                <span class="chip tool-card__chip" data-category="network">Network</span>
+                            </div>
+                        </a>
+                        <a href="tools/ssl-checker.html" class="tool-card" data-category="network">
+                            <div class="tool-card__icon"><i class="fas fa-shield-alt" aria-hidden="true"></i></div>
+                            <div class="tool-card__body">
+                                <h3 class="tool-card__title">SSL/TLS Certificate Checker</h3>
+                                <p class="tool-card__desc">Analyze SSL/TLS certificates for any domain and check their security status</p>
+                                <span class="chip tool-card__chip" data-category="network">Network</span>
+                            </div>
+                        </a>
+                        <a href="tools/subnet-calculator.html" class="tool-card" data-category="network">
+                            <div class="tool-card__icon"><i class="fas fa-network-wired" aria-hidden="true"></i></div>
+                            <div class="tool-card__body">
+                                <h3 class="tool-card__title">Subnet Calculator</h3>
+                                <p class="tool-card__desc">Calculate subnet information, IP ranges, and network details from CIDR notation</p>
+                                <span class="chip tool-card__chip" data-category="network">Network</span>
+                            </div>
+                        </a>
+                    </div>
+
+                    <div id="no-results-message" class="no-results-message hidden">
+                        <div class="empty-state__icon"><i class="fas fa-search" aria-hidden="true"></i></div>
+                        <div class="empty-state__title">No tools match your search</div>
+                        <div>Try a different keyword or pick a different category.</div>
+                    </div>
                 </div>
-            </div>
-        </section>
-    </main>
+            </main>
 
-    <footer>
-        <div class="container">
-            <p>&copy; <span id="current-year">2025</span> Devtools. All rights reserved.</p>
-            <p>
-                <a href="https://github.com/irfansofyana/Devtools" target="_blank">GitHub</a> |
-                <a href="https://github.com/irfansofyana/Devtools/issues" target="_blank">Report Issues</a>
-            </p>
+            <footer class="app-footer">
+                <p>&copy; <span id="current-year">2025</span> Devtools — open-source on
+                    <a href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener">GitHub</a> ·
+                    <a href="https://github.com/irfansofyana/Devtools/issues" target="_blank" rel="noopener">Report issues</a>
+                </p>
+            </footer>
         </div>
-    </footer>
+    </div>
 
     <script src="js/theme.js"></script>
     <script src="js/main.js"></script>

--- a/js/main.js
+++ b/js/main.js
@@ -1,88 +1,145 @@
 /**
- * Main JavaScript functionality for Devtools
+ * Devtools — shared utilities.
+ *
+ * Exposes:
+ *   showError(message, elementId)    — display dismissable error
+ *   showSuccess(message, elementId)  — display dismissable success
+ *   downloadTextFile(content, name)  — trigger a file download
+ *   copyToClipboard(text, btn)       — programmatic copy with button feedback
+ *
+ * Tool pages can opt-in by:
+ *   - giving a button `data-copy="<targetId>"`; the click handler reads the
+ *     value of an <input>/<textarea>, OR the textContent of any other element
+ *     (e.g. <pre>, <code>) and copies it.
+ *
+ * The previous implementation only supported `.value`, which silently copied
+ * empty strings when the target was a <code> element (e.g. JSON formatter).
  */
 document.addEventListener('DOMContentLoaded', () => {
-    // Set current year in footer
     const currentYearElement = document.getElementById('current-year');
     if (currentYearElement) {
         currentYearElement.textContent = new Date().getFullYear();
     }
 
-    // Initialize copy to clipboard functionality
+    populateToolPageTitle();
     initCopyToClipboard();
 });
 
 /**
- * Initialize copy to clipboard functionality for all elements with data-copy attribute
+ * On tool pages, mirror the page <h1> into the top-bar title slot
+ * so the sticky header always shows the current tool name.
+ */
+function populateToolPageTitle() {
+    const slot = document.querySelector('.tool-page-shell .top-bar__title');
+    if (!slot || slot.textContent.trim()) return;
+    const h1 = document.querySelector('.tool-header h1, main h1');
+    if (h1) slot.textContent = h1.textContent.trim();
+}
+
+/**
+ * Initialise the global delegated click handler for `[data-copy]` buttons.
  */
 function initCopyToClipboard() {
     document.addEventListener('click', (e) => {
-        const target = e.target.closest('[data-copy]');
+        const trigger = e.target.closest('[data-copy]');
+        if (!trigger) return;
+
+        const target = document.getElementById(trigger.dataset.copy);
         if (!target) return;
-        
-        const textToCopy = document.getElementById(target.dataset.copy)?.value || '';
-        if (!textToCopy) return;
-        
-        navigator.clipboard.writeText(textToCopy)
-            .then(() => {
-                // Show success feedback
-                const originalText = target.textContent;
-                target.textContent = 'Copied!';
-                target.classList.add('copied');
-                
-                // Reset after 2 seconds
-                setTimeout(() => {
-                    target.textContent = originalText;
-                    target.classList.remove('copied');
-                }, 2000);
-            })
-            .catch(err => {
-                console.error('Failed to copy text: ', err);
-            });
+
+        const text = readCopyableText(target);
+        if (!text) return;
+
+        copyToClipboard(text, trigger);
     });
 }
 
 /**
- * Show an error message
- * @param {string} message - The error message to display
- * @param {string} elementId - The ID of the element to show the error in
+ * Read text from any element type (input, textarea, code/pre, generic block).
+ * @param {HTMLElement} el
+ * @returns {string}
+ */
+function readCopyableText(el) {
+    if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
+        return el.value || '';
+    }
+    // <pre>, <code>, <div>, etc.
+    return el.innerText || el.textContent || '';
+}
+
+/**
+ * Copy a string to clipboard and show a brief "Copied!" state on the button.
+ * @param {string} text
+ * @param {HTMLElement} [btn]
+ * @returns {Promise<boolean>}
+ */
+function copyToClipboard(text, btn) {
+    const finish = (ok) => {
+        if (!btn) return;
+        const original = btn.textContent;
+        btn.textContent = ok ? 'Copied!' : 'Copy failed';
+        btn.classList.add('copied');
+        setTimeout(() => {
+            btn.textContent = original;
+            btn.classList.remove('copied');
+        }, 1800);
+    };
+
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+        return navigator.clipboard.writeText(text)
+            .then(() => { finish(true); return true; })
+            .catch(() => { fallbackCopy(text); finish(true); return true; });
+    }
+    fallbackCopy(text);
+    finish(true);
+    return Promise.resolve(true);
+}
+
+function fallbackCopy(text) {
+    const ta = document.createElement('textarea');
+    ta.value = text;
+    ta.setAttribute('readonly', '');
+    ta.style.position = 'absolute';
+    ta.style.left = '-9999px';
+    document.body.appendChild(ta);
+    ta.select();
+    try { document.execCommand('copy'); } catch (_) { /* ignore */ }
+    document.body.removeChild(ta);
+}
+
+/**
+ * Show an error message inside an alert element (auto-hides after 5s).
+ * Wraps the message in an alert--error look automatically.
  */
 function showError(message, elementId) {
-    const errorElement = document.getElementById(elementId);
-    if (errorElement) {
-        errorElement.textContent = message;
-        errorElement.classList.remove('hidden');
-        
-        // Hide after 5 seconds
-        setTimeout(() => {
-            errorElement.classList.add('hidden');
-        }, 5000);
-    }
+    const el = document.getElementById(elementId);
+    if (!el) return;
+    el.textContent = message;
+    el.classList.remove('hidden');
+    el.classList.add('alert', 'alert--error');
+    if (!el.hasAttribute('role')) el.setAttribute('role', 'alert');
+    if (!el.hasAttribute('aria-live')) el.setAttribute('aria-live', 'polite');
+    clearTimeout(el._hideTimer);
+    el._hideTimer = setTimeout(() => el.classList.add('hidden'), 5000);
 }
 
 /**
- * Show a success message
- * @param {string} message - The success message to display
- * @param {string} elementId - The ID of the element to show the message in
+ * Show a success message inside an alert element (auto-hides after 5s).
  */
 function showSuccess(message, elementId) {
-    const successElement = document.getElementById(elementId);
-    if (successElement) {
-        successElement.textContent = message;
-        successElement.classList.remove('hidden');
-        
-        // Hide after 5 seconds
-        setTimeout(() => {
-            successElement.classList.add('hidden');
-        }, 5000);
-    }
+    const el = document.getElementById(elementId);
+    if (!el) return;
+    el.textContent = message;
+    el.classList.remove('hidden');
+    el.classList.add('alert', 'alert--success');
+    if (!el.hasAttribute('role')) el.setAttribute('role', 'status');
+    if (!el.hasAttribute('aria-live')) el.setAttribute('aria-live', 'polite');
+    clearTimeout(el._hideTimer);
+    el._hideTimer = setTimeout(() => el.classList.add('hidden'), 5000);
 }
 
 /**
- * Utility function to create a download link for text content
- * @param {string} content - The content to download
- * @param {string} filename - The filename for the download
- * @param {string} mimeType - The MIME type of the content
+ * Trigger a download of a text blob.
  */
 function downloadTextFile(content, filename, mimeType = 'text/plain') {
     const blob = new Blob([content], { type: mimeType });
@@ -90,6 +147,8 @@ function downloadTextFile(content, filename, mimeType = 'text/plain') {
     const a = document.createElement('a');
     a.href = url;
     a.download = filename;
+    document.body.appendChild(a);
     a.click();
+    document.body.removeChild(a);
     URL.revokeObjectURL(url);
 }

--- a/js/search.js
+++ b/js/search.js
@@ -1,227 +1,184 @@
 /**
- * Tool search and filtering functionality
+ * Devtools — homepage search, category sidebar, keyboard shortcuts.
+ *
+ * Behaviour:
+ * - Reads `data-category` from each `.tool-card` in the HTML (no DOM injection
+ *   of category tags at runtime — the chips are already in the markup).
+ * - Renders a category list with counts into the sidebar.
+ * - Wires search input + category clicks to filter the grid.
+ * - Persists the active category in localStorage.
+ * - Ctrl/Cmd+K focuses the search input; Esc clears it.
+ * - Hamburger toggles the sidebar on mobile.
  */
 
-// Tool categories with their associated tools
-const toolCategories = {
-    'Text': [
-        'String Case Converter', 'Line Sort/Dedupe', 'Backslash Escape/Unescape', 
-        'Random String Generator', 'Text Diff Utility', 'Vim-Style Code Editor'
-    ],
-    'Encoding': [
-        'Base64 Encoder/Decoder', 'URL Encoder/Decoder', 'ASCII <> HEX Converter'
-    ],
-    'Data Format': [
-        'JSON Beautifier/Minifier', 'JSON <-> YAML Converter', 'CSV <> JSON Converter',
-        'CSV Visualizer', 'JSON to Protobuf', 'JSON/YAML Explorer'
-    ],
-    'Web': [
-        'URL Parser', 'URL to Markdown', 'CURL Constructor', 'JWT Decoder'
-    ],
-    'Crypto': [
-        'Hash Generator', 'UUID Generator', 'Password Generator', 'Secret Share'
-    ],
-    'Time': [
-        'Timestamp Converter', 'Crontab Generator'
-    ],
-    'Visual': [
-        'QR Code Reader/Generator', 'Markdown Preview', 'Mermaid Diagram Editor',
-        'OCR Tool', 'Color Converter', 'ASCII Art Generator'
-    ],
-    'API': [
-        'API Mock Data Generator', 'Regex Tester'
-    ],
-    'Network': [
-        'IP Address Lookup', 'SSL/TLS Certificate Checker', 'Subnet Calculator'
-    ]
-};
+const TOOL_CATEGORIES = [
+    { id: 'all',         label: 'All Tools',  icon: 'fa-th-large' },
+    { id: 'text',        label: 'Text',       icon: 'fa-align-left' },
+    { id: 'encoding',    label: 'Encoding',   icon: 'fa-exchange-alt' },
+    { id: 'data format', label: 'Data',       icon: 'fa-database' },
+    { id: 'web',         label: 'Web',        icon: 'fa-globe' },
+    { id: 'crypto',      label: 'Crypto',     icon: 'fa-shield-alt' },
+    { id: 'time',        label: 'Time',       icon: 'fa-clock' },
+    { id: 'visual',      label: 'Visual',     icon: 'fa-image' },
+    { id: 'api',         label: 'API',        icon: 'fa-plug' },
+    { id: 'network',     label: 'Network',    icon: 'fa-network-wired' },
+];
 
-// Initialize search and filtering functionality
+const STORAGE_KEY = 'devtools-active-category';
+
 document.addEventListener('DOMContentLoaded', () => {
-    initializeSearchAndFilter();
-});
+    const grid = document.getElementById('tools-grid');
+    if (!grid) return;
 
-/**
- * Initialize the search and filtering functionality
- */
-function initializeSearchAndFilter() {
-    // Get the tools grid element
-    const toolsGrid = document.querySelector('.tools-grid');
-    if (!toolsGrid) return;
-    
-    // Get all tool cards
-    const toolCards = Array.from(document.querySelectorAll('.tool-card'));
-    
-    // Create search and filter container
-    const searchFilterContainer = document.createElement('div');
-    searchFilterContainer.className = 'search-filter-container mb-3';
-    
-    // Create search input
-    const searchContainer = document.createElement('div');
-    searchContainer.className = 'search-container';
-    
-    const searchInput = document.createElement('input');
-    searchInput.type = 'text';
-    searchInput.id = 'tool-search';
-    searchInput.className = 'search-input';
-    searchInput.placeholder = 'Search tools...';
-    searchInput.setAttribute('aria-label', 'Search tools');
-    
-    const searchIcon = document.createElement('i');
-    searchIcon.className = 'fas fa-search search-icon';
-    searchIcon.setAttribute('aria-hidden', 'true');
-    
-    const clearButton = document.createElement('button');
-    clearButton.className = 'search-clear-btn hidden';
-    clearButton.innerHTML = '&times;';
-    clearButton.setAttribute('aria-label', 'Clear search');
-    clearButton.setAttribute('type', 'button');
-    
-    searchContainer.appendChild(searchInput);
-    searchContainer.appendChild(searchIcon);
-    searchContainer.appendChild(clearButton);
-    
-    // Add event listener for clear button
-    clearButton.addEventListener('click', () => {
-        searchInput.value = '';
-        clearButton.classList.add('hidden');
-        filterTools('', categorySelect.value);
-        searchInput.focus();
-    });
-    
-    // Show/hide clear button based on input
-    searchInput.addEventListener('input', () => {
-        if (searchInput.value.length > 0) {
-            clearButton.classList.remove('hidden');
-            searchIcon.style.right = 'calc(var(--spacing-md) * 4)';
-        } else {
-            clearButton.classList.add('hidden');
-            searchIcon.style.right = 'var(--spacing-md)';
-        }
-    });
-    
-    // Create category filter
-    const filterContainer = document.createElement('div');
-    filterContainer.className = 'filter-container';
-    
-    const filterLabel = document.createElement('span');
-    filterLabel.className = 'filter-label';
-    filterLabel.textContent = 'Filter by:';
-    
-    const categorySelect = document.createElement('select');
-    categorySelect.id = 'category-filter';
-    categorySelect.className = 'category-select';
-    categorySelect.setAttribute('aria-label', 'Filter by category');
-    
-    // Add "All" option
-    const allOption = document.createElement('option');
-    allOption.value = 'all';
-    allOption.textContent = 'All Categories';
-    categorySelect.appendChild(allOption);
-    
-    // Add category options
-    Object.keys(toolCategories).forEach(category => {
-        const option = document.createElement('option');
-        option.value = category.toLowerCase();
-        option.textContent = category;
-        categorySelect.appendChild(option);
-    });
-    
-    filterContainer.appendChild(filterLabel);
-    filterContainer.appendChild(categorySelect);
-    
-    // Add search and filter to container
-    searchFilterContainer.appendChild(searchContainer);
-    searchFilterContainer.appendChild(filterContainer);
-    
-    // Add tag to each tool card
-    toolCards.forEach(card => {
-        const toolName = card.querySelector('h3').textContent;
-        let toolCategory = 'Other';
-        
-        // Find the category for this tool
-        for (const [category, tools] of Object.entries(toolCategories)) {
-            if (tools.some(tool => toolName.includes(tool))) {
-                toolCategory = category;
-                break;
-            }
-        }
-        
-        // Add category as a data attribute
-        card.setAttribute('data-category', toolCategory.toLowerCase());
-        
-        // Add category tag to the card
-        const tagElement = document.createElement('span');
-        tagElement.className = 'category-tag';
-        tagElement.textContent = toolCategory;
-        card.appendChild(tagElement);
-    });
-    
-    // Insert search and filter before the tools grid
-    const toolsSection = document.querySelector('.tools .container');
-    toolsSection.insertBefore(searchFilterContainer, toolsSection.querySelector('h2').nextSibling);
-    
-    // Add event listeners for search and filter
-    searchInput.addEventListener('input', () => {
-        filterTools(searchInput.value, categorySelect.value);
-    });
-    
-    categorySelect.addEventListener('change', () => {
-        filterTools(searchInput.value, categorySelect.value);
-    });
-    
-    // Initial filter (show all)
-    filterTools('', 'all');
-}
+    const cards = Array.from(grid.querySelectorAll('.tool-card'));
+    const searchInput = document.getElementById('tool-search');
+    const clearBtn = document.getElementById('search-clear');
+    const navContainer = document.getElementById('category-nav');
+    const topBarTitle = document.querySelector('.top-bar__title');
+    const toolCountEl = document.getElementById('tool-count');
 
-/**
- * Filter tools based on search text and category
- * @param {string} searchText - The search text
- * @param {string} category - The selected category
- */
-function filterTools(searchText, category) {
-    const toolCards = Array.from(document.querySelectorAll('.tool-card'));
-    const noResultsMessage = document.getElementById('no-results-message') || createNoResultsMessage();
-    
-    searchText = searchText.toLowerCase();
-    let visibleCount = 0;
-    
-    toolCards.forEach(card => {
-        const toolName = card.querySelector('h3').textContent.toLowerCase();
-        const toolDescription = card.querySelector('p').textContent.toLowerCase();
-        const toolCategory = card.getAttribute('data-category');
-        
-        const matchesSearch = toolName.includes(searchText) || toolDescription.includes(searchText);
-        const matchesCategory = category === 'all' || toolCategory === category;
-        
-        if (matchesSearch && matchesCategory) {
-            card.style.display = '';
-            visibleCount++;
-        } else {
-            card.style.display = 'none';
-        }
-    });
-    
-    // Show/hide no results message
-    if (visibleCount === 0) {
-        noResultsMessage.style.display = 'block';
-    } else {
-        noResultsMessage.style.display = 'none';
+    // Update total tool count in hero strip
+    if (toolCountEl) {
+        toolCountEl.textContent = `${cards.length} tools`;
     }
-}
 
-/**
- * Create a "no results" message element
- * @returns {HTMLElement} The created element
- */
-function createNoResultsMessage() {
-    const toolsGrid = document.querySelector('.tools-grid');
-    const message = document.createElement('div');
-    message.id = 'no-results-message';
-    message.className = 'no-results-message';
-    message.textContent = 'No tools match your search criteria.';
-    message.style.display = 'none';
-    
-    toolsGrid.parentNode.insertBefore(message, toolsGrid.nextSibling);
-    return message;
-}
+    let activeCategory = loadActiveCategory();
+    let activeQuery = '';
+
+    renderSidebar();
+    applyFilter();
+    setupSearch();
+    setupKeyboardShortcuts();
+    setupMobileSidebar();
+
+    function renderSidebar() {
+        if (!navContainer) return;
+        const counts = countByCategory(cards);
+        navContainer.innerHTML = '';
+        TOOL_CATEGORIES.forEach(cat => {
+            const count = cat.id === 'all' ? cards.length : (counts[cat.id] || 0);
+            if (cat.id !== 'all' && count === 0) return;
+            const link = document.createElement('button');
+            link.type = 'button';
+            link.className = 'sidebar__link';
+            link.dataset.category = cat.id;
+            link.setAttribute('aria-pressed', String(cat.id === activeCategory));
+            if (cat.id === activeCategory) link.classList.add('is-active');
+            link.innerHTML = `
+                <span class="sidebar__link-label">
+                    <span class="sidebar__link-icon"><i class="fas ${cat.icon}" aria-hidden="true"></i></span>
+                    ${cat.label}
+                </span>
+                <span class="sidebar__count">${count}</span>
+            `;
+            link.addEventListener('click', () => {
+                setActiveCategory(cat.id);
+                closeMobileSidebar();
+            });
+            navContainer.appendChild(link);
+        });
+    }
+
+    function countByCategory(allCards) {
+        return allCards.reduce((acc, card) => {
+            const c = card.getAttribute('data-category') || 'other';
+            acc[c] = (acc[c] || 0) + 1;
+            return acc;
+        }, {});
+    }
+
+    function setActiveCategory(id) {
+        activeCategory = id;
+        try { localStorage.setItem(STORAGE_KEY, id); } catch (_) { /* ignore */ }
+        navContainer.querySelectorAll('.sidebar__link').forEach(el => {
+            const isActive = el.dataset.category === id;
+            el.classList.toggle('is-active', isActive);
+            el.setAttribute('aria-pressed', String(isActive));
+        });
+        if (topBarTitle) {
+            const cat = TOOL_CATEGORIES.find(c => c.id === id);
+            topBarTitle.textContent = cat ? cat.label : 'All Tools';
+        }
+        applyFilter();
+    }
+
+    function loadActiveCategory() {
+        try {
+            const stored = localStorage.getItem(STORAGE_KEY);
+            if (stored && TOOL_CATEGORIES.some(c => c.id === stored)) return stored;
+        } catch (_) { /* ignore */ }
+        return 'all';
+    }
+
+    function setupSearch() {
+        if (!searchInput) return;
+        searchInput.addEventListener('input', () => {
+            activeQuery = searchInput.value.trim().toLowerCase();
+            if (clearBtn) clearBtn.classList.toggle('hidden', activeQuery.length === 0);
+            applyFilter();
+        });
+        if (clearBtn) {
+            clearBtn.addEventListener('click', () => {
+                searchInput.value = '';
+                activeQuery = '';
+                clearBtn.classList.add('hidden');
+                applyFilter();
+                searchInput.focus();
+            });
+        }
+    }
+
+    function setupKeyboardShortcuts() {
+        document.addEventListener('keydown', (e) => {
+            const isMac = navigator.platform.toUpperCase().includes('MAC');
+            const cmdK = (isMac ? e.metaKey : e.ctrlKey) && e.key.toLowerCase() === 'k';
+            if (cmdK) {
+                e.preventDefault();
+                searchInput?.focus();
+                searchInput?.select();
+            }
+            if (e.key === 'Escape' && document.activeElement === searchInput) {
+                searchInput.value = '';
+                activeQuery = '';
+                clearBtn?.classList.add('hidden');
+                applyFilter();
+                searchInput.blur();
+            }
+        });
+    }
+
+    function setupMobileSidebar() {
+        const toggle = document.getElementById('sidebar-toggle');
+        const scrim = document.getElementById('sidebar-scrim');
+        if (!toggle) return;
+        toggle.addEventListener('click', () => {
+            const open = !document.body.classList.contains('sidebar-open');
+            document.body.classList.toggle('sidebar-open', open);
+            toggle.setAttribute('aria-expanded', String(open));
+        });
+        scrim?.addEventListener('click', closeMobileSidebar);
+    }
+
+    function closeMobileSidebar() {
+        if (!document.body.classList.contains('sidebar-open')) return;
+        document.body.classList.remove('sidebar-open');
+        document.getElementById('sidebar-toggle')?.setAttribute('aria-expanded', 'false');
+    }
+
+    function applyFilter() {
+        const noResults = document.getElementById('no-results-message');
+        let visible = 0;
+        cards.forEach(card => {
+            const cat = card.getAttribute('data-category') || 'other';
+            const title = card.querySelector('.tool-card__title, h3')?.textContent.toLowerCase() || '';
+            const desc = card.querySelector('.tool-card__desc, p')?.textContent.toLowerCase() || '';
+            const matchesCat = activeCategory === 'all' || cat === activeCategory;
+            const matchesQuery = activeQuery === '' ||
+                title.includes(activeQuery) || desc.includes(activeQuery);
+            const show = matchesCat && matchesQuery;
+            card.style.display = show ? '' : 'none';
+            if (show) visible++;
+        });
+        if (noResults) noResults.classList.toggle('hidden', visible !== 0);
+    }
+});

--- a/js/theme.js
+++ b/js/theme.js
@@ -1,84 +1,66 @@
 /**
- * Enhanced theme switcher functionality for Devtools
- * Handles light/dark theme preferences and persistence with smooth transitions
+ * Devtools — theme switcher.
+ * - Persists choice in localStorage (key: Devtools-theme).
+ * - Falls back to prefers-color-scheme.
+ * - Updates aria-pressed and aria-label on the toggle button so screen
+ *   readers describe state rather than reading raw emoji.
+ * - Respects prefers-reduced-motion (no spin animation).
  */
-document.addEventListener('DOMContentLoaded', () => {
-    const themeToggleBtn = document.getElementById('theme-toggle-btn');
+(function () {
+    const STORAGE_KEY = 'Devtools-theme';
     const root = document.documentElement;
-    
-    // Check for saved theme preference or use preferred color scheme
-    const savedTheme = localStorage.getItem('Devtools-theme');
-    const prefersDarkScheme = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    
-    // Set initial theme without transition (on page load)
-    root.style.transition = 'none';
-    if (savedTheme) {
-        root.setAttribute('data-theme', savedTheme);
-    } else if (prefersDarkScheme) {
-        root.setAttribute('data-theme', 'dark');
+
+    // Apply initial theme as early as possible to avoid FOUC.
+    try {
+        const saved = localStorage.getItem(STORAGE_KEY);
+        const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+        const initial = saved || (prefersDark ? 'dark' : 'light');
+        root.setAttribute('data-theme', initial);
+    } catch (_) {
+        // ignore — storage might be unavailable
     }
-    
-    // Force a reflow to ensure the transition: none is applied
-    // before we remove it to allow transitions again
-    root.offsetHeight;
-    root.style.transition = '';
-    
-    // Add animation class to theme toggle button
-    themeToggleBtn.classList.add('theme-toggle-animated');
-    
-    // Toggle theme when button is clicked with animation
-    themeToggleBtn.addEventListener('click', () => {
-        // Add animation class to button
-        themeToggleBtn.classList.add('theme-toggle-spin');
-        
-        // Get current theme and determine new theme
-        const currentTheme = root.getAttribute('data-theme');
-        const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
-        
-        // Apply a subtle fade effect to the whole page during transition
-        document.body.classList.add('theme-transitioning');
-        
-        // Set the new theme after a small delay for visual effect
-        setTimeout(() => {
-            root.setAttribute('data-theme', newTheme);
-            localStorage.setItem('Devtools-theme', newTheme);
-            
-            // Remove the fade effect after the transition completes
-            setTimeout(() => {
-                document.body.classList.remove('theme-transitioning');
-            }, 300);
-            
-            // Remove the spin animation class after it completes
-            setTimeout(() => {
-                themeToggleBtn.classList.remove('theme-toggle-spin');
-            }, 500);
-        }, 50);
+
+    document.addEventListener('DOMContentLoaded', () => {
+        const btn = document.getElementById('theme-toggle-btn');
+        if (!btn) return;
+
+        const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        if (!prefersReduced) {
+            btn.style.transition = 'transform 0.4s cubic-bezier(0.18, 0.89, 0.32, 1.28)';
+        }
+
+        updateButtonState(btn, root.getAttribute('data-theme'));
+
+        btn.addEventListener('click', () => {
+            const current = root.getAttribute('data-theme') || 'light';
+            const next = current === 'dark' ? 'light' : 'dark';
+            root.setAttribute('data-theme', next);
+            try { localStorage.setItem(STORAGE_KEY, next); } catch (_) { /* ignore */ }
+            updateButtonState(btn, next);
+
+            if (!prefersReduced) {
+                btn.style.transform = 'rotate(360deg)';
+                setTimeout(() => { btn.style.transform = ''; }, 400);
+            }
+        });
+
+        // Follow OS theme if user hasn't explicitly chosen.
+        window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
+            try {
+                if (localStorage.getItem(STORAGE_KEY)) return;
+            } catch (_) { /* ignore */ }
+            const next = e.matches ? 'dark' : 'light';
+            root.setAttribute('data-theme', next);
+            updateButtonState(btn, next);
+        });
     });
-    
-    // Add theme transition styles dynamically
-    const style = document.createElement('style');
-    style.textContent = `
-        .theme-toggle-animated {
-            transition: transform 0.5s cubic-bezier(0.18, 0.89, 0.32, 1.28);
-        }
-        
-        .theme-toggle-spin {
-            transform: rotate(180deg);
-        }
-        
-        .theme-transitioning {
-            transition: opacity 0.3s ease;
-            opacity: 0.92;
-        }
-    `;
-    document.head.appendChild(style);
-    
-    // Listen for system theme changes
-    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', e => {
-        if (!localStorage.getItem('Devtools-theme')) {
-            // Only auto-switch if user hasn't manually set a preference
-            const newTheme = e.matches ? 'dark' : 'light';
-            root.setAttribute('data-theme', newTheme);
-        }
-    });
-});
+
+    function updateButtonState(btn, theme) {
+        const isDark = theme === 'dark';
+        btn.setAttribute('aria-pressed', String(isDark));
+        btn.setAttribute('aria-label',
+            isDark ? 'Switch to light theme' : 'Switch to dark theme');
+        btn.setAttribute('title',
+            isDark ? 'Switch to light theme' : 'Switch to dark theme');
+    }
+})();

--- a/tools/api-mock-generator.html
+++ b/tools/api-mock-generator.html
@@ -7,6 +7,11 @@
     <title>API Mock Data Generator | Devtools</title>
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="stylesheet" href="../css/theme.css">
+    <link rel="stylesheet" href="../css/layout.css">
+    <link rel="stylesheet" href="../css/components.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
     <style>
         .template-container {
@@ -309,25 +314,24 @@
             text-decoration: underline;
         }
     </style>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
-<body>
-    <header>
-        <div class="container">
-            <div class="logo">
-                <a href="../index.html">Devtools</a>
-            </div>
-            <nav>
-                <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="https://github.com/irfansofyana/devtools" target="_blank">GitHub</a></li>
-                </ul>
-            </nav>
-            <div class="theme-toggle">
-                <button id="theme-toggle-btn" aria-label="Toggle dark/light theme">
-                    <span class="icon light-icon">☀️</span>
-                    <span class="icon dark-icon">🌙</span>
-                </button>
-            </div>
+<body class="tool-page-shell">
+    <header class="top-bar">
+        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
+            <i class="fas fa-arrow-left" aria-hidden="true"></i>
+            <span>All tools</span>
+        </a>
+        <div class="top-bar__title"></div>
+        <div class="toolbar__spacer"></div>
+        <div class="top-bar__actions">
+            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+                <i class="fab fa-github" aria-hidden="true"></i>
+            </a>
+            <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
+                <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+                <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            </button>
         </div>
     </header>
 

--- a/tools/ascii-art-generator.html
+++ b/tools/ascii-art-generator.html
@@ -7,26 +7,30 @@
     <title>ASCII Art Generator | Devtools</title>
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="stylesheet" href="../css/theme.css">
+    <link rel="stylesheet" href="../css/layout.css">
+    <link rel="stylesheet" href="../css/components.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
-<body>
-    <header>
-        <div class="container">
-            <div class="logo">
-                <a href="../index.html">Devtools</a>
-            </div>
-            <nav>
-                <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="https://github.com/irfansofyana/devtools" target="_blank">GitHub</a></li>
-                </ul>
-            </nav>
-            <div class="theme-toggle">
-                <button id="theme-toggle-btn" aria-label="Toggle dark/light theme">
-                    <span class="icon light-icon">☀️</span>
-                    <span class="icon dark-icon">🌙</span>
-                </button>
-            </div>
+<body class="tool-page-shell">
+    <header class="top-bar">
+        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
+            <i class="fas fa-arrow-left" aria-hidden="true"></i>
+            <span>All tools</span>
+        </a>
+        <div class="top-bar__title"></div>
+        <div class="toolbar__spacer"></div>
+        <div class="top-bar__actions">
+            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+                <i class="fab fa-github" aria-hidden="true"></i>
+            </a>
+            <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
+                <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+                <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            </button>
         </div>
     </header>
 

--- a/tools/ascii-hex-converter.html
+++ b/tools/ascii-hex-converter.html
@@ -7,29 +7,32 @@
     <title>ASCII <> HEX Converter | Devtools</title>
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="stylesheet" href="../css/theme.css">
+    <link rel="stylesheet" href="../css/layout.css">
+    <link rel="stylesheet" href="../css/components.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
     <link rel="icon" href="../assets/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="../assets/favicon-32x32.png" type="image/png" sizes="32x32">
     <link rel="apple-touch-icon" href="../assets/apple-touch-icon.png">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
-<body>
-    <header>
-        <div class="container">
-            <div class="logo">
-                <a href="../index.html"><i class="fas fa-tools"></i> Devtools</a>
-            </div>
-            <nav>
-                <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="https://github.com/irfansofyana/devutils" target="_blank">GitHub</a></li>
-                </ul>
-            </nav>
-            <div class="theme-toggle">
-                <button id="theme-toggle-btn" aria-label="Toggle dark/light theme">
-                    <span class="icon light-icon">☀️</span>
-                    <span class="icon dark-icon">🌙</span>
-                </button>
-            </div>
+<body class="tool-page-shell">
+    <header class="top-bar">
+        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
+            <i class="fas fa-arrow-left" aria-hidden="true"></i>
+            <span>All tools</span>
+        </a>
+        <div class="top-bar__title"></div>
+        <div class="toolbar__spacer"></div>
+        <div class="top-bar__actions">
+            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+                <i class="fab fa-github" aria-hidden="true"></i>
+            </a>
+            <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
+                <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+                <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            </button>
         </div>
     </header>
 

--- a/tools/backslash-escape-unescape.html
+++ b/tools/backslash-escape-unescape.html
@@ -7,26 +7,30 @@
     <title>Backslash Escape/Unescape | Devtools</title>
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="stylesheet" href="../css/theme.css">
+    <link rel="stylesheet" href="../css/layout.css">
+    <link rel="stylesheet" href="../css/components.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
-<body>
-    <header>
-        <div class="container">
-            <div class="logo">
-                <a href="../index.html">Devtools</a>
-            </div>
-            <nav>
-                <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="https://github.com/irfansofyana/devtools" target="_blank">GitHub</a></li>
-                </ul>
-            </nav>
-            <div class="theme-toggle">
-                <button id="theme-toggle-btn" aria-label="Toggle dark/light theme">
-                    <span class="icon light-icon">☀️</span>
-                    <span class="icon dark-icon">🌙</span>
-                </button>
-            </div>
+<body class="tool-page-shell">
+    <header class="top-bar">
+        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
+            <i class="fas fa-arrow-left" aria-hidden="true"></i>
+            <span>All tools</span>
+        </a>
+        <div class="top-bar__title"></div>
+        <div class="toolbar__spacer"></div>
+        <div class="top-bar__actions">
+            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+                <i class="fab fa-github" aria-hidden="true"></i>
+            </a>
+            <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
+                <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+                <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            </button>
         </div>
     </header>
 

--- a/tools/base64-encoder-decoder.html
+++ b/tools/base64-encoder-decoder.html
@@ -7,26 +7,30 @@
     <title>Base64 Encoder/Decoder | Devtools</title>
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="stylesheet" href="../css/theme.css">
+    <link rel="stylesheet" href="../css/layout.css">
+    <link rel="stylesheet" href="../css/components.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
-<body>
-    <header>
-        <div class="container">
-            <div class="logo">
-                <a href="../index.html">Devtools</a>
-            </div>
-            <nav>
-                <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="https://github.com/irfansofyana/devtools" target="_blank">GitHub</a></li>
-                </ul>
-            </nav>
-            <div class="theme-toggle">
-                <button id="theme-toggle-btn" aria-label="Toggle dark/light theme">
-                    <span class="icon light-icon">☀️</span>
-                    <span class="icon dark-icon">🌙</span>
-                </button>
-            </div>
+<body class="tool-page-shell">
+    <header class="top-bar">
+        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
+            <i class="fas fa-arrow-left" aria-hidden="true"></i>
+            <span>All tools</span>
+        </a>
+        <div class="top-bar__title"></div>
+        <div class="toolbar__spacer"></div>
+        <div class="top-bar__actions">
+            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+                <i class="fab fa-github" aria-hidden="true"></i>
+            </a>
+            <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
+                <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+                <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            </button>
         </div>
     </header>
 

--- a/tools/color-converter.html
+++ b/tools/color-converter.html
@@ -7,26 +7,30 @@
     <title>Color Converter | Devtools</title>
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="stylesheet" href="../css/theme.css">
+    <link rel="stylesheet" href="../css/layout.css">
+    <link rel="stylesheet" href="../css/components.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
-<body>
-    <header>
-        <div class="container">
-            <div class="logo">
-                <a href="../index.html">Devtools</a>
-            </div>
-            <nav>
-                <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="https://github.com/irfansofyana/devtools" target="_blank">GitHub</a></li>
-                </ul>
-            </nav>
-            <div class="theme-toggle">
-                <button id="theme-toggle-btn" aria-label="Toggle dark/light theme">
-                    <span class="icon light-icon">☀️</span>
-                    <span class="icon dark-icon">🌙</span>
-                </button>
-            </div>
+<body class="tool-page-shell">
+    <header class="top-bar">
+        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
+            <i class="fas fa-arrow-left" aria-hidden="true"></i>
+            <span>All tools</span>
+        </a>
+        <div class="top-bar__title"></div>
+        <div class="toolbar__spacer"></div>
+        <div class="top-bar__actions">
+            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+                <i class="fab fa-github" aria-hidden="true"></i>
+            </a>
+            <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
+                <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+                <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            </button>
         </div>
     </header>
 

--- a/tools/crontab-generator.html
+++ b/tools/crontab-generator.html
@@ -7,26 +7,30 @@
     <title>Crontab Generator | Devtools</title>
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="stylesheet" href="../css/theme.css">
+    <link rel="stylesheet" href="../css/layout.css">
+    <link rel="stylesheet" href="../css/components.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
-<body>
-    <header>
-        <div class="container">
-            <div class="logo">
-                <a href="../index.html">Devtools</a>
-            </div>
-            <nav>
-                <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="https://github.com/irfansofyana/devtools" target="_blank">GitHub</a></li>
-                </ul>
-            </nav>
-            <div class="theme-toggle">
-                <button id="theme-toggle-btn" aria-label="Toggle dark/light theme">
-                    <span class="icon light-icon">☀️</span>
-                    <span class="icon dark-icon">🌙</span>
-                </button>
-            </div>
+<body class="tool-page-shell">
+    <header class="top-bar">
+        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
+            <i class="fas fa-arrow-left" aria-hidden="true"></i>
+            <span>All tools</span>
+        </a>
+        <div class="top-bar__title"></div>
+        <div class="toolbar__spacer"></div>
+        <div class="top-bar__actions">
+            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+                <i class="fab fa-github" aria-hidden="true"></i>
+            </a>
+            <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
+                <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+                <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            </button>
         </div>
     </header>
 

--- a/tools/csv-json-converter.html
+++ b/tools/csv-json-converter.html
@@ -7,26 +7,30 @@
     <title>CSV <> JSON Converter | Devtools</title>
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="stylesheet" href="../css/theme.css">
+    <link rel="stylesheet" href="../css/layout.css">
+    <link rel="stylesheet" href="../css/components.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
-<body>
-    <header>
-        <div class="container">
-            <div class="logo">
-                <a href="../index.html">Devtools</a>
-            </div>
-            <nav>
-                <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="https://github.com/irfansofyana/devtools" target="_blank">GitHub</a></li>
-                </ul>
-            </nav>
-            <div class="theme-toggle">
-                <button id="theme-toggle-btn" aria-label="Toggle dark/light theme">
-                    <span class="icon light-icon">☀️</span>
-                    <span class="icon dark-icon">🌙</span>
-                </button>
-            </div>
+<body class="tool-page-shell">
+    <header class="top-bar">
+        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
+            <i class="fas fa-arrow-left" aria-hidden="true"></i>
+            <span>All tools</span>
+        </a>
+        <div class="top-bar__title"></div>
+        <div class="toolbar__spacer"></div>
+        <div class="top-bar__actions">
+            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+                <i class="fab fa-github" aria-hidden="true"></i>
+            </a>
+            <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
+                <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+                <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            </button>
         </div>
     </header>
 

--- a/tools/csv-visualizer.html
+++ b/tools/csv-visualizer.html
@@ -7,27 +7,31 @@
     <title>CSV Visualizer | Devtools</title>
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="stylesheet" href="../css/theme.css">
+    <link rel="stylesheet" href="../css/layout.css">
+    <link rel="stylesheet" href="../css/components.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
     <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
-<body>
-    <header>
-        <div class="container">
-            <div class="logo">
-                <a href="../index.html">Devtools</a>
-            </div>
-            <nav>
-                <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="https://github.com/irfansofyana/devtools" target="_blank">GitHub</a></li>
-                </ul>
-            </nav>
-            <div class="theme-toggle">
-                <button id="theme-toggle-btn" aria-label="Toggle dark/light theme">
-                    <span class="icon light-icon">☀️</span>
-                    <span class="icon dark-icon">🌙</span>
-                </button>
-            </div>
+<body class="tool-page-shell">
+    <header class="top-bar">
+        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
+            <i class="fas fa-arrow-left" aria-hidden="true"></i>
+            <span>All tools</span>
+        </a>
+        <div class="top-bar__title"></div>
+        <div class="toolbar__spacer"></div>
+        <div class="top-bar__actions">
+            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+                <i class="fab fa-github" aria-hidden="true"></i>
+            </a>
+            <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
+                <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+                <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            </button>
         </div>
     </header>
 

--- a/tools/curl-constructor.html
+++ b/tools/curl-constructor.html
@@ -7,26 +7,30 @@
     <title>CURL Constructor | Devtools</title>
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="stylesheet" href="../css/theme.css">
+    <link rel="stylesheet" href="../css/layout.css">
+    <link rel="stylesheet" href="../css/components.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
-<body>
-    <header>
-        <div class="container">
-            <div class="logo">
-                <a href="../index.html">Devtools</a>
-            </div>
-            <nav>
-                <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="https://github.com/irfansofyana/devtools" target="_blank">GitHub</a></li>
-                </ul>
-            </nav>
-            <div class="theme-toggle">
-                <button id="theme-toggle-btn" aria-label="Toggle dark/light theme">
-                    <span class="icon light-icon">☀️</span>
-                    <span class="icon dark-icon">🌙</span>
-                </button>
-            </div>
+<body class="tool-page-shell">
+    <header class="top-bar">
+        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
+            <i class="fas fa-arrow-left" aria-hidden="true"></i>
+            <span>All tools</span>
+        </a>
+        <div class="top-bar__title"></div>
+        <div class="toolbar__spacer"></div>
+        <div class="top-bar__actions">
+            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+                <i class="fab fa-github" aria-hidden="true"></i>
+            </a>
+            <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
+                <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+                <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            </button>
         </div>
     </header>
 

--- a/tools/hash-generator.html
+++ b/tools/hash-generator.html
@@ -7,26 +7,30 @@
     <title>Hash Generator | Devtools</title>
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="stylesheet" href="../css/theme.css">
+    <link rel="stylesheet" href="../css/layout.css">
+    <link rel="stylesheet" href="../css/components.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
-<body>
-    <header>
-        <div class="container">
-            <div class="logo">
-                <a href="../index.html">Devtools</a>
-            </div>
-            <nav>
-                <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="https://github.com/irfansofyana/devtools" target="_blank">GitHub</a></li>
-                </ul>
-            </nav>
-            <div class="theme-toggle">
-                <button id="theme-toggle-btn" aria-label="Toggle dark/light theme">
-                    <span class="icon light-icon">☀️</span>
-                    <span class="icon dark-icon">🌙</span>
-                </button>
-            </div>
+<body class="tool-page-shell">
+    <header class="top-bar">
+        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
+            <i class="fas fa-arrow-left" aria-hidden="true"></i>
+            <span>All tools</span>
+        </a>
+        <div class="top-bar__title"></div>
+        <div class="toolbar__spacer"></div>
+        <div class="top-bar__actions">
+            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+                <i class="fab fa-github" aria-hidden="true"></i>
+            </a>
+            <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
+                <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+                <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            </button>
         </div>
     </header>
 

--- a/tools/ip-lookup.html
+++ b/tools/ip-lookup.html
@@ -6,26 +6,30 @@
     <title>IP Address Lookup - DevTools</title>
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="stylesheet" href="../css/theme.css">
+    <link rel="stylesheet" href="../css/layout.css">
+    <link rel="stylesheet" href="../css/components.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
     <link rel="icon" type="image/x-icon" href="../assets/favicon.ico">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
-<body>
-    <header>
-        <div class="container">
-            <div class="logo">
-                <a href="../index.html">Devtools</a>
-            </div>
-            <nav>
-                <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="https://github.com/irfansofyana/devtools" target="_blank">GitHub</a></li>
-                </ul>
-            </nav>
-            <div class="theme-toggle">
-                <button id="theme-toggle-btn" aria-label="Toggle dark/light theme">
-                    <span class="icon light-icon">☀️</span>
-                    <span class="icon dark-icon">🌙</span>
-                </button>
-            </div>
+<body class="tool-page-shell">
+    <header class="top-bar">
+        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
+            <i class="fas fa-arrow-left" aria-hidden="true"></i>
+            <span>All tools</span>
+        </a>
+        <div class="top-bar__title"></div>
+        <div class="toolbar__spacer"></div>
+        <div class="top-bar__actions">
+            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+                <i class="fab fa-github" aria-hidden="true"></i>
+            </a>
+            <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
+                <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+                <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            </button>
         </div>
     </header>
 

--- a/tools/json-formatter.html
+++ b/tools/json-formatter.html
@@ -7,29 +7,33 @@
     <title>JSON Beautifier/Minifier | Devtools</title>
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="stylesheet" href="../css/theme.css">
+    <link rel="stylesheet" href="../css/layout.css">
+    <link rel="stylesheet" href="../css/components.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
     <!-- Prism.js for syntax highlighting -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.24.1/themes/prism.min.css">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.24.1/themes/prism-dark.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
-<body>
-    <header>
-        <div class="container">
-            <div class="logo">
-                <a href="../index.html">Devtools</a>
-            </div>
-            <nav>
-                <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="https://github.com/irfansofyana/devtools" target="_blank">GitHub</a></li>
-                </ul>
-            </nav>
-            <div class="theme-toggle">
-                <button id="theme-toggle-btn" aria-label="Toggle dark/light theme">
-                    <span class="icon light-icon">☀️</span>
-                    <span class="icon dark-icon">🌙</span>
-                </button>
-            </div>
+<body class="tool-page-shell">
+    <header class="top-bar">
+        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
+            <i class="fas fa-arrow-left" aria-hidden="true"></i>
+            <span>All tools</span>
+        </a>
+        <div class="top-bar__title"></div>
+        <div class="toolbar__spacer"></div>
+        <div class="top-bar__actions">
+            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+                <i class="fab fa-github" aria-hidden="true"></i>
+            </a>
+            <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
+                <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+                <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            </button>
         </div>
     </header>
 

--- a/tools/json-to-protobuf.html
+++ b/tools/json-to-protobuf.html
@@ -7,26 +7,30 @@
     <title>JSON to Protobuf Generator | Devtools</title>
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="stylesheet" href="../css/theme.css">
+    <link rel="stylesheet" href="../css/layout.css">
+    <link rel="stylesheet" href="../css/components.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
-<body>
-    <header>
-        <div class="container">
-            <div class="logo">
-                <a href="../index.html">Devtools</a>
-            </div>
-            <nav>
-                <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="https://github.com/irfansofyana/devtools" target="_blank">GitHub</a></li>
-                </ul>
-            </nav>
-            <div class="theme-toggle">
-                <button id="theme-toggle-btn" aria-label="Toggle dark/light theme">
-                    <span class="icon light-icon">☀️</span>
-                    <span class="icon dark-icon">🌙</span>
-                </button>
-            </div>
+<body class="tool-page-shell">
+    <header class="top-bar">
+        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
+            <i class="fas fa-arrow-left" aria-hidden="true"></i>
+            <span>All tools</span>
+        </a>
+        <div class="top-bar__title"></div>
+        <div class="toolbar__spacer"></div>
+        <div class="top-bar__actions">
+            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+                <i class="fab fa-github" aria-hidden="true"></i>
+            </a>
+            <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
+                <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+                <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            </button>
         </div>
     </header>
 

--- a/tools/json-yaml-converter.html
+++ b/tools/json-yaml-converter.html
@@ -7,26 +7,30 @@
     <title>JSON <-> YAML Converter | Devtools</title>
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="stylesheet" href="../css/theme.css">
+    <link rel="stylesheet" href="../css/layout.css">
+    <link rel="stylesheet" href="../css/components.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
-<body>
-    <header>
-        <div class="container">
-            <div class="logo">
-                <a href="../index.html">Devtools</a>
-            </div>
-            <nav>
-                <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="https://github.com/irfansofyana/devtools" target="_blank">GitHub</a></li>
-                </ul>
-            </nav>
-            <div class="theme-toggle">
-                <button id="theme-toggle-btn" aria-label="Toggle dark/light theme">
-                    <span class="icon light-icon">☀️</span>
-                    <span class="icon dark-icon">🌙</span>
-                </button>
-            </div>
+<body class="tool-page-shell">
+    <header class="top-bar">
+        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
+            <i class="fas fa-arrow-left" aria-hidden="true"></i>
+            <span>All tools</span>
+        </a>
+        <div class="top-bar__title"></div>
+        <div class="toolbar__spacer"></div>
+        <div class="top-bar__actions">
+            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+                <i class="fab fa-github" aria-hidden="true"></i>
+            </a>
+            <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
+                <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+                <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            </button>
         </div>
     </header>
 

--- a/tools/json-yaml-explorer.html
+++ b/tools/json-yaml-explorer.html
@@ -7,31 +7,35 @@
     <title>JSON/YAML Explorer | Devtools</title>
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="stylesheet" href="../css/theme.css">
+    <link rel="stylesheet" href="../css/layout.css">
+    <link rel="stylesheet" href="../css/components.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
     <!-- Include jsoneditor for visualization -->
     <link href="https://cdnjs.cloudflare.com/ajax/libs/jsoneditor/9.10.0/jsoneditor.min.css" rel="stylesheet" type="text/css">
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jsoneditor/9.10.0/jsoneditor.min.js"></script>
     <!-- Include js-yaml for YAML parsing -->
     <script src="https://cdnjs.cloudflare.com/ajax/libs/js-yaml/4.1.0/js-yaml.min.js"></script>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
-<body>
-    <header>
-        <div class="container">
-            <div class="logo">
-                <a href="../index.html">Devtools</a>
-            </div>
-            <nav>
-                <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="https://github.com/irfansofyana/devtools" target="_blank">GitHub</a></li>
-                </ul>
-            </nav>
-            <div class="theme-toggle">
-                <button id="theme-toggle-btn" aria-label="Toggle dark/light theme">
-                    <span class="icon light-icon">☀️</span>
-                    <span class="icon dark-icon">🌙</span>
-                </button>
-            </div>
+<body class="tool-page-shell">
+    <header class="top-bar">
+        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
+            <i class="fas fa-arrow-left" aria-hidden="true"></i>
+            <span>All tools</span>
+        </a>
+        <div class="top-bar__title"></div>
+        <div class="toolbar__spacer"></div>
+        <div class="top-bar__actions">
+            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+                <i class="fab fa-github" aria-hidden="true"></i>
+            </a>
+            <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
+                <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+                <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            </button>
         </div>
     </header>
 

--- a/tools/jwt-decoder.html
+++ b/tools/jwt-decoder.html
@@ -7,26 +7,30 @@
     <title>JWT Decoder | Devtools</title>
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="stylesheet" href="../css/theme.css">
+    <link rel="stylesheet" href="../css/layout.css">
+    <link rel="stylesheet" href="../css/components.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
-<body>
-    <header>
-        <div class="container">
-            <div class="logo">
-                <a href="../index.html">Devtools</a>
-            </div>
-            <nav>
-                <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="https://github.com/irfansofyana/devtools" target="_blank">GitHub</a></li>
-                </ul>
-            </nav>
-            <div class="theme-toggle">
-                <button id="theme-toggle-btn" aria-label="Toggle dark/light theme">
-                    <span class="icon light-icon">☀️</span>
-                    <span class="icon dark-icon">🌙</span>
-                </button>
-            </div>
+<body class="tool-page-shell">
+    <header class="top-bar">
+        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
+            <i class="fas fa-arrow-left" aria-hidden="true"></i>
+            <span>All tools</span>
+        </a>
+        <div class="top-bar__title"></div>
+        <div class="toolbar__spacer"></div>
+        <div class="top-bar__actions">
+            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+                <i class="fab fa-github" aria-hidden="true"></i>
+            </a>
+            <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
+                <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+                <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            </button>
         </div>
     </header>
 

--- a/tools/line-sort-dedupe.html
+++ b/tools/line-sort-dedupe.html
@@ -7,27 +7,30 @@
     <title>Line Sort/Dedupe | Devtools</title>
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="stylesheet" href="../css/theme.css">
+    <link rel="stylesheet" href="../css/layout.css">
+    <link rel="stylesheet" href="../css/components.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
-<body>
-    <header>
-        <div class="container">
-            <div class="logo">
-                <a href="../index.html">Devtools</a>
-            </div>
-            <nav>
-                <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="https://github.com/irfansofyana/devtools" target="_blank">GitHub</a></li>
-                </ul>
-            </nav>
-            <div class="theme-toggle">
-                <button id="theme-toggle-btn" aria-label="Toggle dark/light theme">
-                    <span class="icon light-icon">☀️</span>
-                    <span class="icon dark-icon">🌙</span>
-                </button>
-            </div>
+<body class="tool-page-shell">
+    <header class="top-bar">
+        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
+            <i class="fas fa-arrow-left" aria-hidden="true"></i>
+            <span>All tools</span>
+        </a>
+        <div class="top-bar__title"></div>
+        <div class="toolbar__spacer"></div>
+        <div class="top-bar__actions">
+            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+                <i class="fab fa-github" aria-hidden="true"></i>
+            </a>
+            <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
+                <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+                <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            </button>
         </div>
     </header>
 

--- a/tools/markdown-preview.html
+++ b/tools/markdown-preview.html
@@ -7,6 +7,11 @@
     <title>Markdown Preview | Devtools</title>
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="stylesheet" href="../css/theme.css">
+    <link rel="stylesheet" href="../css/layout.css">
+    <link rel="stylesheet" href="../css/components.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
     <style>
         .preview-container {
@@ -170,25 +175,24 @@
             height: auto;
         }
     </style>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
-<body>
-    <header>
-        <div class="container">
-            <div class="logo">
-                <a href="../index.html">Devtools</a>
-            </div>
-            <nav>
-                <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="https://github.com/irfansofyana/devtools" target="_blank">GitHub</a></li>
-                </ul>
-            </nav>
-            <div class="theme-toggle">
-                <button id="theme-toggle-btn" aria-label="Toggle dark/light theme">
-                    <span class="icon light-icon">☀️</span>
-                    <span class="icon dark-icon">🌙</span>
-                </button>
-            </div>
+<body class="tool-page-shell">
+    <header class="top-bar">
+        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
+            <i class="fas fa-arrow-left" aria-hidden="true"></i>
+            <span>All tools</span>
+        </a>
+        <div class="top-bar__title"></div>
+        <div class="toolbar__spacer"></div>
+        <div class="top-bar__actions">
+            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+                <i class="fab fa-github" aria-hidden="true"></i>
+            </a>
+            <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
+                <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+                <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            </button>
         </div>
     </header>
 

--- a/tools/mermaid-diagram-editor.html
+++ b/tools/mermaid-diagram-editor.html
@@ -7,6 +7,11 @@
     <title>Mermaid Diagram Editor | Devtools</title>
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="stylesheet" href="../css/theme.css">
+    <link rel="stylesheet" href="../css/layout.css">
+    <link rel="stylesheet" href="../css/components.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
     <!-- Mermaid.js for diagram rendering -->
     <script src="https://cdn.jsdelivr.net/npm/mermaid@10.6.1/dist/mermaid.min.js"></script>
@@ -122,25 +127,24 @@
             margin-top: var(--spacing-md);
         }
     </style>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
-<body>
-    <header>
-        <div class="container">
-            <div class="logo">
-                <a href="../index.html">Devtools</a>
-            </div>
-            <nav>
-                <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="https://github.com/irfansofyana/devtools" target="_blank">GitHub</a></li>
-                </ul>
-            </nav>
-            <div class="theme-toggle">
-                <button id="theme-toggle-btn" aria-label="Toggle dark/light theme">
-                    <span class="icon light-icon">☀️</span>
-                    <span class="icon dark-icon">🌙</span>
-                </button>
-            </div>
+<body class="tool-page-shell">
+    <header class="top-bar">
+        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
+            <i class="fas fa-arrow-left" aria-hidden="true"></i>
+            <span>All tools</span>
+        </a>
+        <div class="top-bar__title"></div>
+        <div class="toolbar__spacer"></div>
+        <div class="top-bar__actions">
+            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+                <i class="fab fa-github" aria-hidden="true"></i>
+            </a>
+            <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
+                <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+                <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            </button>
         </div>
     </header>
 

--- a/tools/ocr-tool.html
+++ b/tools/ocr-tool.html
@@ -7,6 +7,11 @@
     <title>OCR Tool | Devtools</title>
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="stylesheet" href="../css/theme.css">
+    <link rel="stylesheet" href="../css/layout.css">
+    <link rel="stylesheet" href="../css/components.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
     <style>
         .drop-zone {
@@ -93,25 +98,24 @@
             }
         }
     </style>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
-<body>
-    <header>
-        <div class="container">
-            <div class="logo">
-                <a href="../index.html">Devtools</a>
-            </div>
-            <nav>
-                <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="https://github.com/irfansofyana/devutils" target="_blank">GitHub</a></li>
-                </ul>
-            </nav>
-            <div class="theme-toggle">
-                <button id="theme-toggle-btn" aria-label="Toggle dark/light theme">
-                    <span class="icon light-icon">☀️</span>
-                    <span class="icon dark-icon">🌙</span>
-                </button>
-            </div>
+<body class="tool-page-shell">
+    <header class="top-bar">
+        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
+            <i class="fas fa-arrow-left" aria-hidden="true"></i>
+            <span>All tools</span>
+        </a>
+        <div class="top-bar__title"></div>
+        <div class="toolbar__spacer"></div>
+        <div class="top-bar__actions">
+            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+                <i class="fab fa-github" aria-hidden="true"></i>
+            </a>
+            <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
+                <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+                <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            </button>
         </div>
     </header>
 

--- a/tools/password-generator.html
+++ b/tools/password-generator.html
@@ -7,26 +7,30 @@
     <title>Random Password Generator | Devtools</title>
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="stylesheet" href="../css/theme.css">
+    <link rel="stylesheet" href="../css/layout.css">
+    <link rel="stylesheet" href="../css/components.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
-<body>
-    <header>
-        <div class="container">
-            <div class="logo">
-                <a href="../index.html">Devtools</a>
-            </div>
-            <nav>
-                <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="https://github.com/irfansofyana/devtools" target="_blank">GitHub</a></li>
-                </ul>
-            </nav>
-            <div class="theme-toggle">
-                <button id="theme-toggle-btn" aria-label="Toggle dark/light theme">
-                    <span class="icon light-icon">☀️</span>
-                    <span class="icon dark-icon">🌙</span>
-                </button>
-            </div>
+<body class="tool-page-shell">
+    <header class="top-bar">
+        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
+            <i class="fas fa-arrow-left" aria-hidden="true"></i>
+            <span>All tools</span>
+        </a>
+        <div class="top-bar__title"></div>
+        <div class="toolbar__spacer"></div>
+        <div class="top-bar__actions">
+            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+                <i class="fab fa-github" aria-hidden="true"></i>
+            </a>
+            <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
+                <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+                <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            </button>
         </div>
     </header>
 

--- a/tools/qr-code-tool.html
+++ b/tools/qr-code-tool.html
@@ -7,6 +7,11 @@
     <title>QR Code Reader/Generator | Devtools</title>
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="stylesheet" href="../css/theme.css">
+    <link rel="stylesheet" href="../css/layout.css">
+    <link rel="stylesheet" href="../css/components.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
     <link rel="icon" href="../assets/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="../assets/favicon-32x32.png" type="image/png" sizes="32x32">
     <link rel="apple-touch-icon" href="../assets/apple-touch-icon.png">
@@ -14,24 +19,22 @@
     <script src="https://cdn.jsdelivr.net/npm/qrcode@1.5.1/build/qrcode.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/jsqr@1.4.0/dist/jsQR.min.js"></script>
 </head>
-<body>
-    <header>
-        <div class="container">
-            <div class="logo">
-                <a href="../index.html"><i class="fas fa-tools"></i> Devtools</a>
-            </div>
-            <nav>
-                <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="https://github.com/irfansofyana/devutils" target="_blank">GitHub</a></li>
-                </ul>
-            </nav>
-            <div class="theme-toggle">
-                <button id="theme-toggle-btn" aria-label="Toggle dark/light theme">
-                    <span class="icon light-icon">☀️</span>
-                    <span class="icon dark-icon">🌙</span>
-                </button>
-            </div>
+<body class="tool-page-shell">
+    <header class="top-bar">
+        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
+            <i class="fas fa-arrow-left" aria-hidden="true"></i>
+            <span>All tools</span>
+        </a>
+        <div class="top-bar__title"></div>
+        <div class="toolbar__spacer"></div>
+        <div class="top-bar__actions">
+            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+                <i class="fab fa-github" aria-hidden="true"></i>
+            </a>
+            <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
+                <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+                <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            </button>
         </div>
     </header>
 

--- a/tools/regex-tester.html
+++ b/tools/regex-tester.html
@@ -7,26 +7,30 @@
     <title>Regular Expression Tester | Devtools</title>
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="stylesheet" href="../css/theme.css">
+    <link rel="stylesheet" href="../css/layout.css">
+    <link rel="stylesheet" href="../css/components.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
-<body>
-    <header>
-        <div class="container">
-            <div class="logo">
-                <a href="../index.html">Devtools</a>
-            </div>
-            <nav>
-                <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="https://github.com/irfansofyana/devtools" target="_blank">GitHub</a></li>
-                </ul>
-            </nav>
-            <div class="theme-toggle">
-                <button id="theme-toggle-btn" aria-label="Toggle dark/light theme">
-                    <span class="icon light-icon">☀️</span>
-                    <span class="icon dark-icon">🌙</span>
-                </button>
-            </div>
+<body class="tool-page-shell">
+    <header class="top-bar">
+        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
+            <i class="fas fa-arrow-left" aria-hidden="true"></i>
+            <span>All tools</span>
+        </a>
+        <div class="top-bar__title"></div>
+        <div class="toolbar__spacer"></div>
+        <div class="top-bar__actions">
+            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+                <i class="fab fa-github" aria-hidden="true"></i>
+            </a>
+            <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
+                <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+                <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            </button>
         </div>
     </header>
 

--- a/tools/secret-share.html
+++ b/tools/secret-share.html
@@ -7,27 +7,30 @@
     <title>Secret Share | Devtools</title>
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="stylesheet" href="../css/theme.css">
+    <link rel="stylesheet" href="../css/layout.css">
+    <link rel="stylesheet" href="../css/components.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
 </head>
-<body>
-    <header>
-        <div class="container">
-            <div class="logo">
-                <a href="../index.html">Devtools</a>
-            </div>
-            <nav>
-                <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="https://github.com/irfansofyana/devtools" target="_blank">GitHub</a></li>
-                </ul>
-            </nav>
-            <div class="theme-toggle">
-                <button id="theme-toggle-btn" aria-label="Toggle dark/light theme">
-                    <span class="icon light-icon">☀️</span>
-                    <span class="icon dark-icon">🌙</span>
-                </button>
-            </div>
+<body class="tool-page-shell">
+    <header class="top-bar">
+        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
+            <i class="fas fa-arrow-left" aria-hidden="true"></i>
+            <span>All tools</span>
+        </a>
+        <div class="top-bar__title"></div>
+        <div class="toolbar__spacer"></div>
+        <div class="top-bar__actions">
+            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+                <i class="fab fa-github" aria-hidden="true"></i>
+            </a>
+            <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
+                <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+                <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            </button>
         </div>
     </header>
 

--- a/tools/ssl-checker.html
+++ b/tools/ssl-checker.html
@@ -6,26 +6,30 @@
     <title>SSL/TLS Certificate Checker - DevTools</title>
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="stylesheet" href="../css/theme.css">
+    <link rel="stylesheet" href="../css/layout.css">
+    <link rel="stylesheet" href="../css/components.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
     <link rel="icon" type="image/x-icon" href="../assets/favicon.ico">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
-<body>
-    <header>
-        <div class="container">
-            <div class="logo">
-                <a href="../index.html">Devtools</a>
-            </div>
-            <nav>
-                <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="https://github.com/irfansofyana/devtools" target="_blank">GitHub</a></li>
-                </ul>
-            </nav>
-            <div class="theme-toggle">
-                <button id="theme-toggle-btn" aria-label="Toggle dark/light theme">
-                    <span class="icon light-icon">☀️</span>
-                    <span class="icon dark-icon">🌙</span>
-                </button>
-            </div>
+<body class="tool-page-shell">
+    <header class="top-bar">
+        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
+            <i class="fas fa-arrow-left" aria-hidden="true"></i>
+            <span>All tools</span>
+        </a>
+        <div class="top-bar__title"></div>
+        <div class="toolbar__spacer"></div>
+        <div class="top-bar__actions">
+            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+                <i class="fab fa-github" aria-hidden="true"></i>
+            </a>
+            <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
+                <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+                <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            </button>
         </div>
     </header>
 

--- a/tools/string-case-converter.html
+++ b/tools/string-case-converter.html
@@ -7,26 +7,30 @@
     <title>String Case Converter | Devtools</title>
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="stylesheet" href="../css/theme.css">
+    <link rel="stylesheet" href="../css/layout.css">
+    <link rel="stylesheet" href="../css/components.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
-<body>
-    <header>
-        <div class="container">
-            <div class="logo">
-                <a href="../index.html">Devtools</a>
-            </div>
-            <nav>
-                <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="https://github.com/irfansofyana/devtools" target="_blank">GitHub</a></li>
-                </ul>
-            </nav>
-            <div class="theme-toggle">
-                <button id="theme-toggle-btn" aria-label="Toggle dark/light theme">
-                    <span class="icon light-icon">☀️</span>
-                    <span class="icon dark-icon">🌙</span>
-                </button>
-            </div>
+<body class="tool-page-shell">
+    <header class="top-bar">
+        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
+            <i class="fas fa-arrow-left" aria-hidden="true"></i>
+            <span>All tools</span>
+        </a>
+        <div class="top-bar__title"></div>
+        <div class="toolbar__spacer"></div>
+        <div class="top-bar__actions">
+            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+                <i class="fab fa-github" aria-hidden="true"></i>
+            </a>
+            <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
+                <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+                <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            </button>
         </div>
     </header>
 

--- a/tools/string-generator.html
+++ b/tools/string-generator.html
@@ -7,26 +7,30 @@
     <title>Random String Generator | Devtools</title>
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="stylesheet" href="../css/theme.css">
+    <link rel="stylesheet" href="../css/layout.css">
+    <link rel="stylesheet" href="../css/components.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
-<body>
-    <header>
-        <div class="container">
-            <div class="logo">
-                <a href="../index.html">Devtools</a>
-            </div>
-            <nav>
-                <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="https://github.com/irfansofyana/devtools" target="_blank">GitHub</a></li>
-                </ul>
-            </nav>
-            <div class="theme-toggle">
-                <button id="theme-toggle-btn" aria-label="Toggle dark/light theme">
-                    <span class="icon light-icon">☀️</span>
-                    <span class="icon dark-icon">🌙</span>
-                </button>
-            </div>
+<body class="tool-page-shell">
+    <header class="top-bar">
+        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
+            <i class="fas fa-arrow-left" aria-hidden="true"></i>
+            <span>All tools</span>
+        </a>
+        <div class="top-bar__title"></div>
+        <div class="toolbar__spacer"></div>
+        <div class="top-bar__actions">
+            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+                <i class="fab fa-github" aria-hidden="true"></i>
+            </a>
+            <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
+                <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+                <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            </button>
         </div>
     </header>
 

--- a/tools/subnet-calculator.html
+++ b/tools/subnet-calculator.html
@@ -6,26 +6,30 @@
     <title>Subnet Calculator - DevTools</title>
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="stylesheet" href="../css/theme.css">
+    <link rel="stylesheet" href="../css/layout.css">
+    <link rel="stylesheet" href="../css/components.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
     <link rel="icon" type="image/x-icon" href="../assets/favicon.ico">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
-<body>
-    <header>
-        <div class="container">
-            <div class="logo">
-                <a href="../index.html">Devtools</a>
-            </div>
-            <nav>
-                <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="https://github.com/irfansofyana/devtools" target="_blank">GitHub</a></li>
-                </ul>
-            </nav>
-            <div class="theme-toggle">
-                <button id="theme-toggle-btn" aria-label="Toggle dark/light theme">
-                    <span class="icon light-icon">☀️</span>
-                    <span class="icon dark-icon">🌙</span>
-                </button>
-            </div>
+<body class="tool-page-shell">
+    <header class="top-bar">
+        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
+            <i class="fas fa-arrow-left" aria-hidden="true"></i>
+            <span>All tools</span>
+        </a>
+        <div class="top-bar__title"></div>
+        <div class="toolbar__spacer"></div>
+        <div class="top-bar__actions">
+            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+                <i class="fab fa-github" aria-hidden="true"></i>
+            </a>
+            <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
+                <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+                <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            </button>
         </div>
     </header>
 

--- a/tools/text-diff.html
+++ b/tools/text-diff.html
@@ -7,6 +7,11 @@
     <title>Text Diff Utility | Devtools</title>
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="stylesheet" href="../css/theme.css">
+    <link rel="stylesheet" href="../css/layout.css">
+    <link rel="stylesheet" href="../css/components.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
     <style>
         /* Diff specific styles */
@@ -96,25 +101,24 @@
             text-decoration: line-through;
         }
     </style>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
-<body>
-    <header>
-        <div class="container">
-            <div class="logo">
-                <a href="../index.html">Devtools</a>
-            </div>
-            <nav>
-                <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="https://github.com/irfansofyana/devtools" target="_blank">GitHub</a></li>
-                </ul>
-            </nav>
-            <div class="theme-toggle">
-                <button id="theme-toggle-btn" aria-label="Toggle dark/light theme">
-                    <span class="icon light-icon">☀️</span>
-                    <span class="icon dark-icon">🌙</span>
-                </button>
-            </div>
+<body class="tool-page-shell">
+    <header class="top-bar">
+        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
+            <i class="fas fa-arrow-left" aria-hidden="true"></i>
+            <span>All tools</span>
+        </a>
+        <div class="top-bar__title"></div>
+        <div class="toolbar__spacer"></div>
+        <div class="top-bar__actions">
+            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+                <i class="fab fa-github" aria-hidden="true"></i>
+            </a>
+            <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
+                <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+                <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            </button>
         </div>
     </header>
 

--- a/tools/timestamp-converter.html
+++ b/tools/timestamp-converter.html
@@ -7,26 +7,30 @@
     <title>Timestamp Converter | Devtools</title>
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="stylesheet" href="../css/theme.css">
+    <link rel="stylesheet" href="../css/layout.css">
+    <link rel="stylesheet" href="../css/components.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
-<body>
-    <header>
-        <div class="container">
-            <div class="logo">
-                <a href="../index.html">Devtools</a>
-            </div>
-            <nav>
-                <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="https://github.com/irfansofyana/devtools" target="_blank">GitHub</a></li>
-                </ul>
-            </nav>
-            <div class="theme-toggle">
-                <button id="theme-toggle-btn" aria-label="Toggle dark/light theme">
-                    <span class="icon light-icon">☀️</span>
-                    <span class="icon dark-icon">🌙</span>
-                </button>
-            </div>
+<body class="tool-page-shell">
+    <header class="top-bar">
+        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
+            <i class="fas fa-arrow-left" aria-hidden="true"></i>
+            <span>All tools</span>
+        </a>
+        <div class="top-bar__title"></div>
+        <div class="toolbar__spacer"></div>
+        <div class="top-bar__actions">
+            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+                <i class="fab fa-github" aria-hidden="true"></i>
+            </a>
+            <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
+                <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+                <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            </button>
         </div>
     </header>
 

--- a/tools/url-encoder-decoder.html
+++ b/tools/url-encoder-decoder.html
@@ -7,26 +7,30 @@
     <title>URL Encoder/Decoder | Devtools</title>
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="stylesheet" href="../css/theme.css">
+    <link rel="stylesheet" href="../css/layout.css">
+    <link rel="stylesheet" href="../css/components.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
-<body>
-    <header>
-        <div class="container">
-            <div class="logo">
-                <a href="../index.html">Devtools</a>
-            </div>
-            <nav>
-                <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="https://github.com/irfansofyana/devtools" target="_blank">GitHub</a></li>
-                </ul>
-            </nav>
-            <div class="theme-toggle">
-                <button id="theme-toggle-btn" aria-label="Toggle dark/light theme">
-                    <span class="icon light-icon">☀️</span>
-                    <span class="icon dark-icon">🌙</span>
-                </button>
-            </div>
+<body class="tool-page-shell">
+    <header class="top-bar">
+        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
+            <i class="fas fa-arrow-left" aria-hidden="true"></i>
+            <span>All tools</span>
+        </a>
+        <div class="top-bar__title"></div>
+        <div class="toolbar__spacer"></div>
+        <div class="top-bar__actions">
+            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+                <i class="fab fa-github" aria-hidden="true"></i>
+            </a>
+            <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
+                <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+                <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            </button>
         </div>
     </header>
 

--- a/tools/url-parser.html
+++ b/tools/url-parser.html
@@ -7,26 +7,30 @@
     <title>URL Parser | Devtools</title>
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="stylesheet" href="../css/theme.css">
+    <link rel="stylesheet" href="../css/layout.css">
+    <link rel="stylesheet" href="../css/components.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
-<body>
-    <header>
-        <div class="container">
-            <div class="logo">
-                <a href="../index.html">Devtools</a>
-            </div>
-            <nav>
-                <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="https://github.com/irfansofyana/devtools" target="_blank">GitHub</a></li>
-                </ul>
-            </nav>
-            <div class="theme-toggle">
-                <button id="theme-toggle-btn" aria-label="Toggle dark/light theme">
-                    <span class="icon light-icon">☀️</span>
-                    <span class="icon dark-icon">🌙</span>
-                </button>
-            </div>
+<body class="tool-page-shell">
+    <header class="top-bar">
+        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
+            <i class="fas fa-arrow-left" aria-hidden="true"></i>
+            <span>All tools</span>
+        </a>
+        <div class="top-bar__title"></div>
+        <div class="toolbar__spacer"></div>
+        <div class="top-bar__actions">
+            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+                <i class="fab fa-github" aria-hidden="true"></i>
+            </a>
+            <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
+                <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+                <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            </button>
         </div>
     </header>
 

--- a/tools/url-to-markdown.html
+++ b/tools/url-to-markdown.html
@@ -7,26 +7,30 @@
     <title>URL to Markdown | Devtools</title>
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="stylesheet" href="../css/theme.css">
+    <link rel="stylesheet" href="../css/layout.css">
+    <link rel="stylesheet" href="../css/components.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
-<body>
-    <header>
-        <div class="container">
-            <div class="logo">
-                <a href="../index.html">Devtools</a>
-            </div>
-            <nav>
-                <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="https://github.com/irfansofyana/devtools" target="_blank">GitHub</a></li>
-                </ul>
-            </nav>
-            <div class="theme-toggle">
-                <button id="theme-toggle-btn" aria-label="Toggle dark/light theme">
-                    <span class="icon light-icon">☀️</span>
-                    <span class="icon dark-icon">🌙</span>
-                </button>
-            </div>
+<body class="tool-page-shell">
+    <header class="top-bar">
+        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
+            <i class="fas fa-arrow-left" aria-hidden="true"></i>
+            <span>All tools</span>
+        </a>
+        <div class="top-bar__title"></div>
+        <div class="toolbar__spacer"></div>
+        <div class="top-bar__actions">
+            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+                <i class="fab fa-github" aria-hidden="true"></i>
+            </a>
+            <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
+                <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+                <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            </button>
         </div>
     </header>
 

--- a/tools/uuid-generator.html
+++ b/tools/uuid-generator.html
@@ -7,26 +7,30 @@
     <title>UUID Generator | Devtools</title>
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="stylesheet" href="../css/theme.css">
+    <link rel="stylesheet" href="../css/layout.css">
+    <link rel="stylesheet" href="../css/components.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
-<body>
-    <header>
-        <div class="container">
-            <div class="logo">
-                <a href="../index.html">Devtools</a>
-            </div>
-            <nav>
-                <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="https://github.com/irfansofyana/devtools" target="_blank">GitHub</a></li>
-                </ul>
-            </nav>
-            <div class="theme-toggle">
-                <button id="theme-toggle-btn" aria-label="Toggle dark/light theme">
-                    <span class="icon light-icon">☀️</span>
-                    <span class="icon dark-icon">🌙</span>
-                </button>
-            </div>
+<body class="tool-page-shell">
+    <header class="top-bar">
+        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
+            <i class="fas fa-arrow-left" aria-hidden="true"></i>
+            <span>All tools</span>
+        </a>
+        <div class="top-bar__title"></div>
+        <div class="toolbar__spacer"></div>
+        <div class="top-bar__actions">
+            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+                <i class="fab fa-github" aria-hidden="true"></i>
+            </a>
+            <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
+                <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+                <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            </button>
         </div>
     </header>
 

--- a/tools/vim-editor.html
+++ b/tools/vim-editor.html
@@ -7,6 +7,11 @@
     <title>Vim-Style Code Editor | Devtools</title>
     <link rel="stylesheet" href="../css/styles.css">
     <link rel="stylesheet" href="../css/theme.css">
+    <link rel="stylesheet" href="../css/layout.css">
+    <link rel="stylesheet" href="../css/components.css">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
     <link rel="icon" href="../assets/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="../assets/favicon-32x32.png" type="image/png" sizes="32x32">
     <!-- CodeMirror CSS -->
@@ -360,25 +365,24 @@
             }
         }
     </style>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
-<body>
-    <header>
-        <div class="container">
-            <div class="logo">
-                <a href="../index.html"><i class="fas fa-tools"></i> Devtools</a>
-            </div>
-            <nav>
-                <ul>
-                    <li><a href="../index.html">Home</a></li>
-                    <li><a href="https://github.com/irfansofyana/devtools" target="_blank">GitHub</a></li>
-                </ul>
-            </nav>
-            <div class="theme-toggle">
-                <button id="theme-toggle-btn" aria-label="Toggle dark/light theme">
-                    <span class="icon light-icon">☀️</span>
-                    <span class="icon dark-icon">🌙</span>
-                </button>
-            </div>
+<body class="tool-page-shell">
+    <header class="top-bar">
+        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
+            <i class="fas fa-arrow-left" aria-hidden="true"></i>
+            <span>All tools</span>
+        </a>
+        <div class="top-bar__title"></div>
+        <div class="toolbar__spacer"></div>
+        <div class="top-bar__actions">
+            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+                <i class="fab fa-github" aria-hidden="true"></i>
+            </a>
+            <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
+                <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+                <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            </button>
         </div>
     </header>
 
@@ -835,6 +839,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.13/mode/shell/shell.min.js"></script>
     
     <script src="../js/theme.js"></script>
+    <script src="../js/main.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {
             // Initialize CodeMirror with Vim keybindings and enhanced features


### PR DESCRIPTION
Restructures the UI into a dashboard-style layout with a persistent
category sidebar, sticky top bar with search (Cmd/Ctrl+K) and theme
toggle, and a redesigned horizontal tool card with category-coloured
accent strips.

Adds a small CSS component layer (.btn, .input, .textarea, .field,
.card, .panel, .chip, .alert, .switch, .kbd, .skeleton) plus a
refreshed design token system (typography scale, spacing scale, radius
and shadow scales, motion tokens, focus ring). Legacy selectors
(.input-group, .input-controls, .options-group, .error-message, etc.)
are aliased to the new component styles so all 36 existing tool pages
adopt the new look without per-page markup changes.

Refines the colour palette (neutral scale, semantic success/warning/
danger/info, per-category accents) for both light and dark themes,
replaces the emoji theme toggle with accessible inline SVG icons that
report state via aria-pressed/aria-label, adds a skip link, fixes the
data-copy clipboard bug that silently copied empty strings from
<code>/<pre> elements, and routes showError/showSuccess through
role=alert/aria-live regions.

All 36 tool pages get a unified top-bar header with a back link, dark
mode toggle, and dynamic tool title; the homepage gains keyboard-driven
search, persistent category selection, and a responsive slide-over
sidebar on mobile.

https://claude.ai/code/session_01H5uqb6eqt5ZQnjuNHHQ1vT