### PR TITLE
refactor(ui): terminal-flavoured pass — drop sidebar, dense sections

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -1,9 +1,6 @@
 /* ============================================================
-   Devtools — Component layer
-   Reusable primitives: button, input, field, card, alert,
-   chip, toolbar, switch, kbd, skeleton.
-   Legacy class aliases are included so existing tool pages
-   adopt the new look without markup edits.
+   Devtools — components
+   Minimal, opinionated. Legacy aliases keep old tool pages working.
    ============================================================ */
 
 /* ============================================================
@@ -17,12 +14,14 @@ button.secondary {
     align-items: center;
     justify-content: center;
     gap: var(--space-2);
-    height: 40px;
-    padding: 0 var(--space-4);
-    border-radius: var(--radius-md);
-    border: 1px solid transparent;
-    font-family: var(--font-display);
-    font-size: var(--text-sm);
+    height: 34px;
+    padding: 0 var(--space-3);
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-strong);
+    background-color: var(--surface-1);
+    color: var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
     font-weight: 500;
     line-height: 1;
     white-space: nowrap;
@@ -30,105 +29,80 @@ button.secondary {
     user-select: none;
     transition: background-color var(--duration-fast) var(--ease-out),
                 border-color var(--duration-fast) var(--ease-out),
-                color var(--duration-fast) var(--ease-out),
-                box-shadow var(--duration-fast) var(--ease-out),
-                transform var(--duration-fast) var(--ease-out);
+                color var(--duration-fast) var(--ease-out);
+}
+
+.btn:hover:not(:disabled),
+button.primary:hover:not(:disabled),
+button.secondary:hover:not(:disabled) {
+    border-color: var(--text-primary);
 }
 
 .btn:focus-visible,
 button.primary:focus-visible,
 button.secondary:focus-visible {
-    outline: none;
-    box-shadow: var(--focus-ring);
+    outline: 1px solid var(--text-primary);
+    outline-offset: 1px;
 }
 
 .btn:disabled,
 button.primary:disabled,
 button.secondary:disabled {
-    opacity: 0.5;
+    opacity: 0.4;
     cursor: not-allowed;
-    transform: none !important;
 }
 
-/* Primary */
+/* Primary — filled, sharp */
 .btn--primary,
 button.primary {
-    background-color: var(--accent-primary);
-    color: var(--text-on-accent);
-    border-color: var(--accent-primary);
-    box-shadow: var(--shadow-xs);
+    background-color: var(--text-primary);
+    color: var(--bg-primary);
+    border-color: var(--text-primary);
 }
 
 .btn--primary:hover:not(:disabled),
 button.primary:hover:not(:disabled) {
-    background-color: var(--accent-secondary);
-    border-color: var(--accent-secondary);
-    box-shadow: var(--shadow-sm);
+    background-color: var(--button-hover);
+    border-color: var(--button-hover);
 }
 
-.btn--primary:active:not(:disabled),
-button.primary:active:not(:disabled) {
-    transform: translateY(1px);
-    box-shadow: var(--shadow-xs);
-}
-
-/* Secondary (subtle surface) */
-.btn--secondary,
+/* Secondary keeps default look (subtle surface) */
 button.secondary {
     background-color: var(--surface-2);
-    color: var(--text-primary);
-    border-color: var(--border-color);
 }
 
-.btn--secondary:hover:not(:disabled),
 button.secondary:hover:not(:disabled) {
     background-color: var(--surface-3);
-    border-color: var(--border-strong);
 }
 
 /* Ghost */
 .btn--ghost {
     background-color: transparent;
-    color: var(--text-primary);
     border-color: transparent;
+    color: var(--text-secondary);
 }
 
 .btn--ghost:hover:not(:disabled) {
     background-color: var(--surface-2);
-}
-
-/* Danger */
-.btn--danger {
-    background-color: var(--danger);
-    color: #fff;
-    border-color: var(--danger);
-}
-
-.btn--danger:hover:not(:disabled) {
-    background-color: #b91c1c;
-    border-color: #b91c1c;
+    color: var(--text-primary);
+    border-color: transparent;
 }
 
 /* Icon-only */
 .btn--icon,
 button.icon-button {
-    width: 40px;
-    height: 40px;
+    width: 34px;
+    height: 34px;
     padding: 0;
-    font-size: var(--text-base);
 }
 
 .btn--icon-sm {
-    width: 32px;
-    height: 32px;
-    font-size: var(--text-sm);
+    width: 30px;
+    height: 30px;
+    padding: 0;
 }
 
-/* Sizes */
-.btn--sm { height: 32px; padding: 0 var(--space-3); font-size: var(--text-xs); }
-.btn--lg { height: 48px; padding: 0 var(--space-6); font-size: var(--text-base); }
-
-/* Copied feedback (used by main.js) */
+/* Copied feedback */
 .btn.copied,
 button.copied {
     background-color: var(--success) !important;
@@ -137,54 +111,30 @@ button.copied {
 }
 
 /* ============================================================
-   Input / Textarea / Select (component-class form)
-   Note: bare elements (`textarea`, `input[type=text]`, etc.)
-   are styled in theme.css so legacy tool pages still look good.
+   Input (component-class form)
    ============================================================ */
 
-.input,
-.textarea,
-.select {
+.input {
     display: block;
     width: 100%;
-    height: 40px;
+    height: 34px;
     padding: 0 var(--space-3);
-    border-radius: var(--radius-md);
+    border-radius: var(--radius-sm);
     border: 1px solid var(--input-border);
     background-color: var(--input-bg);
     color: var(--text-primary);
-    font-family: inherit;
+    font-family: var(--font-mono);
     font-size: var(--text-sm);
-    transition: border-color var(--duration-fast) var(--ease-out),
-                box-shadow var(--duration-fast) var(--ease-out);
 }
 
-.textarea {
-    height: auto;
-    min-height: 150px;
-    padding: var(--space-3);
-    font-family: var(--font-mono);
-    resize: vertical;
-    line-height: var(--leading-normal);
-}
-
-.input:hover, .textarea:hover, .select:hover {
-    border-color: var(--input-border-hover);
-}
-
-.input:focus, .textarea:focus, .select:focus {
-    outline: none;
-    border-color: var(--input-border-focus);
-    box-shadow: var(--focus-ring);
-}
-
-.input--mono {
-    font-family: var(--font-mono);
+.input:focus {
+    outline: 1px solid var(--text-primary);
+    outline-offset: -1px;
+    border-color: var(--text-primary);
 }
 
 /* ============================================================
-   Field (label + control + helper)
-   Legacy alias: .input-group
+   Field (legacy alias: .input-group)
    ============================================================ */
 
 .field,
@@ -198,25 +148,17 @@ button.copied {
 .field__label,
 .input-group label {
     display: block;
-    font-size: var(--text-sm);
-    font-weight: 600;
-    color: var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    font-weight: 500;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
     margin-bottom: 0;
 }
 
-.field__hint {
-    font-size: var(--text-xs);
-    color: var(--text-muted);
-}
-
-.field__error {
-    font-size: var(--text-xs);
-    color: var(--danger);
-}
-
 /* ============================================================
-   Toolbar (button row)
-   Legacy alias: .input-controls
+   Toolbar (legacy alias: .input-controls)
    ============================================================ */
 
 .toolbar,
@@ -228,136 +170,40 @@ button.copied {
     margin-top: var(--space-3);
 }
 
-.toolbar--end {
-    justify-content: flex-end;
-}
-
-.toolbar--between {
-    justify-content: space-between;
-}
-
-.toolbar__spacer {
-    flex: 1;
-}
+.toolbar__spacer { flex: 1; }
 
 /* ============================================================
-   Card (generic surface)
+   Chip (used sparingly — section count, status)
    ============================================================ */
 
-.card {
-    background-color: var(--surface-1);
-    border: 1px solid var(--border-color);
-    border-radius: var(--radius-lg);
-    padding: var(--space-6);
-    box-shadow: var(--shadow-xs);
-}
-
-.card--interactive {
-    cursor: pointer;
-    transition: transform var(--duration-base) var(--ease-out),
-                box-shadow var(--duration-base) var(--ease-out),
-                border-color var(--duration-base) var(--ease-out);
-}
-
-.card--interactive:hover {
-    transform: translateY(-2px);
-    box-shadow: var(--shadow-md);
-    border-color: var(--border-strong);
-}
-
-.card__title {
-    font-size: var(--text-lg);
-    font-weight: 600;
-    margin-bottom: var(--space-2);
-}
-
-.card__body {
-    color: var(--text-secondary);
-}
-
-/* ============================================================
-   Panel (boxed section inside tool pages)
-   ============================================================ */
-
-.panel {
-    background-color: var(--surface-1);
-    border: 1px solid var(--border-color);
-    border-radius: var(--radius-lg);
-    overflow: hidden;
-}
-
-.panel__header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: var(--space-3) var(--space-4);
-    border-bottom: 1px solid var(--border-color);
-    background-color: var(--surface-2);
-    font-size: var(--text-sm);
-    font-weight: 600;
-}
-
-.panel__body {
-    padding: var(--space-5);
-}
-
-/* ============================================================
-   Chip / Tag (category badge)
-   ============================================================ */
-
-.chip,
-.tag,
-.category-tag {
+.chip {
     display: inline-flex;
     align-items: center;
     gap: var(--space-1);
-    padding: 2px var(--space-2);
-    border-radius: var(--radius-pill);
-    background-color: var(--accent-bg);
-    color: var(--accent-primary);
-    font-size: var(--text-xs);
-    font-weight: 600;
-    letter-spacing: 0.02em;
-    line-height: 1.5;
-    border: 1px solid transparent;
-    white-space: nowrap;
-}
-
-.chip--solid {
-    background-color: var(--accent-primary);
-    color: var(--text-on-accent);
-}
-
-.chip--neutral {
-    background-color: var(--surface-3);
+    padding: 1px var(--space-2);
+    border-radius: var(--radius-sm);
+    background-color: var(--surface-2);
     color: var(--text-secondary);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    font-weight: 500;
+    line-height: 1.6;
+    border: 1px solid var(--border-color);
 }
-
-/* Category-specific chip colour (used on cards) */
-.chip[data-category="text"],          .category-tag[data-category="text"]          { background: rgba(249, 115, 22, 0.12); color: var(--cat-text); }
-.chip[data-category="encoding"],      .category-tag[data-category="encoding"]      { background: rgba(16, 185, 129, 0.12); color: var(--cat-encoding); }
-.chip[data-category="data format"],   .category-tag[data-category="data format"]   { background: rgba(99, 102, 241, 0.12); color: var(--cat-data); }
-.chip[data-category="web"],           .category-tag[data-category="web"]           { background: rgba(6, 182, 212, 0.12); color: var(--cat-web); }
-.chip[data-category="crypto"],        .category-tag[data-category="crypto"]        { background: rgba(239, 68, 68, 0.12); color: var(--cat-crypto); }
-.chip[data-category="time"],          .category-tag[data-category="time"]          { background: rgba(245, 158, 11, 0.12); color: var(--cat-time); }
-.chip[data-category="visual"],        .category-tag[data-category="visual"]        { background: rgba(236, 72, 153, 0.12); color: var(--cat-visual); }
-.chip[data-category="api"],           .category-tag[data-category="api"]           { background: rgba(139, 92, 246, 0.12); color: var(--cat-api); }
-.chip[data-category="network"],       .category-tag[data-category="network"]       { background: rgba(20, 184, 166, 0.12); color: var(--cat-network); }
 
 /* ============================================================
-   Alert / message
-   Legacy aliases: .error-message, .success-message
+   Alert (legacy aliases: .error-message, .success-message)
    ============================================================ */
 
 .alert,
 .error-message,
 .success-message {
-    display: flex;
-    align-items: flex-start;
-    gap: var(--space-2);
+    display: block;
     padding: var(--space-3) var(--space-4);
-    border-radius: var(--radius-md);
+    border-radius: var(--radius-sm);
     border: 1px solid transparent;
+    border-left-width: 3px;
+    font-family: var(--font-mono);
     font-size: var(--text-sm);
     line-height: var(--leading-normal);
     margin-bottom: var(--space-4);
@@ -367,128 +213,35 @@ button.copied {
 .error-message {
     background-color: var(--error-bg);
     color: var(--error-text);
-    border-color: rgba(220, 38, 38, 0.25);
+    border-color: var(--danger);
 }
 
 .alert--success,
 .success-message {
     background-color: var(--success-bg);
     color: var(--success-text);
-    border-color: rgba(22, 163, 74, 0.25);
-}
-
-.alert--warning {
-    background-color: var(--warning-bg);
-    color: var(--warning-text);
-    border-color: rgba(217, 119, 6, 0.25);
-}
-
-.alert--info {
-    background-color: var(--info-bg);
-    color: var(--info-text);
-    border-color: rgba(2, 132, 199, 0.25);
+    border-color: var(--success);
 }
 
 /* ============================================================
-   Switch / Checkbox / Radio (subtle native styling)
+   Native form controls
    ============================================================ */
 
 input[type="checkbox"],
 input[type="radio"] {
-    accent-color: var(--accent-primary);
-    width: 16px;
-    height: 16px;
+    accent-color: var(--accent);
+    width: 14px;
+    height: 14px;
     cursor: pointer;
 }
 
-.switch {
-    position: relative;
-    display: inline-block;
-    width: 36px;
-    height: 20px;
-}
-
-.switch input {
-    opacity: 0;
-    width: 0;
-    height: 0;
-}
-
-.switch__slider {
-    position: absolute;
-    inset: 0;
-    background-color: var(--border-strong);
-    border-radius: var(--radius-pill);
-    transition: background-color var(--duration-fast) var(--ease-out);
-}
-
-.switch__slider::before {
-    content: '';
-    position: absolute;
-    width: 14px;
-    height: 14px;
-    left: 3px;
-    top: 3px;
-    background-color: #fff;
-    border-radius: 50%;
-    transition: transform var(--duration-fast) var(--ease-out);
-}
-
-.switch input:checked + .switch__slider {
-    background-color: var(--accent-primary);
-}
-
-.switch input:checked + .switch__slider::before {
-    transform: translateX(16px);
-}
-
 /* ============================================================
-   Kbd (keyboard hint)
-   ============================================================ */
-
-.kbd {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    min-width: 20px;
-    height: 20px;
-    padding: 0 var(--space-1);
-    background-color: var(--surface-3);
-    border: 1px solid var(--border-color);
-    border-bottom-width: 2px;
-    border-radius: var(--radius-sm);
-    font-family: var(--font-mono);
-    font-size: 0.7rem;
-    color: var(--text-secondary);
-    line-height: 1;
-}
-
-/* ============================================================
-   Skeleton loader
-   ============================================================ */
-
-.skeleton {
-    background: linear-gradient(90deg,
-        var(--surface-2) 25%,
-        var(--surface-3) 50%,
-        var(--surface-2) 75%);
-    background-size: 200% 100%;
-    border-radius: var(--radius-sm);
-    animation: skeleton-shimmer 1.4s ease-in-out infinite;
-}
-
-@keyframes skeleton-shimmer {
-    0% { background-position: 200% 0; }
-    100% { background-position: -200% 0; }
-}
-
-/* ============================================================
-   Legacy tool page surfaces
-   Apply panel-like styling to existing markup without changes.
+   Legacy tool page styling
+   Adopt new look without touching markup.
    ============================================================ */
 
 .tool-content {
-    max-width: 1000px;
+    max-width: 980px;
     margin: 0 auto;
 }
 
@@ -502,23 +255,26 @@ input[type="radio"] {
 .options-group {
     background-color: var(--surface-1);
     border: 1px solid var(--border-color);
-    border-radius: var(--radius-lg);
-    padding: var(--space-4) var(--space-5);
+    border-radius: var(--radius-md);
+    padding: var(--space-4);
     margin-bottom: var(--space-5);
 }
 
 .options-group > label:first-child {
     display: block;
-    font-size: var(--text-sm);
-    font-weight: 600;
-    color: var(--text-primary);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    font-weight: 500;
+    color: var(--text-secondary);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
     margin-bottom: var(--space-3);
 }
 
 .options-controls {
     display: flex;
     flex-wrap: wrap;
-    gap: var(--space-4) var(--space-5);
+    gap: var(--space-3) var(--space-5);
     align-items: center;
 }
 
@@ -533,7 +289,7 @@ input[type="radio"] {
 
 .options-controls input[type="number"] {
     width: 64px;
-    height: 32px;
+    height: 28px;
     text-align: center;
 }
 

--- a/css/layout.css
+++ b/css/layout.css
@@ -1,177 +1,8 @@
 /* ============================================================
-   Devtools — Layout
-   App shell (sidebar + main), top bar, tool grid, tool card,
-   tool page layout, footer, responsive breakpoints.
+   Devtools — layout
+   Single column. Sticky terminal-style top bar.
+   Tools grouped into sections with mono headers.
    ============================================================ */
-
-/* ============================================================
-   App shell
-   ============================================================ */
-
-.app-shell {
-    display: grid;
-    grid-template-columns: 260px 1fr;
-    min-height: 100vh;
-}
-
-.app-main {
-    display: flex;
-    flex-direction: column;
-    min-width: 0; /* prevent grid blowout */
-}
-
-/* ============================================================
-   Sidebar
-   ============================================================ */
-
-.sidebar {
-    position: sticky;
-    top: 0;
-    height: 100vh;
-    display: flex;
-    flex-direction: column;
-    background-color: var(--sidebar-bg);
-    border-right: 1px solid var(--sidebar-border);
-    overflow-y: auto;
-    z-index: 50;
-}
-
-.sidebar__brand {
-    display: flex;
-    align-items: center;
-    gap: var(--space-2);
-    padding: var(--space-5) var(--space-5) var(--space-4);
-    font-family: var(--font-display);
-    font-weight: 700;
-    font-size: var(--text-lg);
-    color: var(--text-primary);
-    letter-spacing: -0.02em;
-}
-
-.sidebar__brand-mark {
-    width: 32px;
-    height: 32px;
-    display: grid;
-    place-items: center;
-    border-radius: var(--radius-md);
-    background: linear-gradient(135deg, var(--accent-primary), var(--accent-secondary));
-    color: #fff;
-}
-
-.sidebar__brand-mark svg {
-    width: 18px;
-    height: 18px;
-}
-
-.sidebar__section {
-    padding: var(--space-4) var(--space-3);
-    border-top: 1px solid var(--sidebar-border);
-}
-
-.sidebar__section:first-of-type {
-    border-top: 0;
-}
-
-.sidebar__heading {
-    font-size: var(--text-xs);
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    color: var(--text-muted);
-    font-weight: 600;
-    padding: 0 var(--space-3);
-    margin-bottom: var(--space-2);
-}
-
-.sidebar__nav {
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-}
-
-.sidebar__link {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: var(--space-2);
-    padding: var(--space-2) var(--space-3);
-    border-radius: var(--radius-md);
-    color: var(--text-secondary);
-    font-size: var(--text-sm);
-    font-weight: 500;
-    cursor: pointer;
-    transition: background-color var(--duration-fast) var(--ease-out),
-                color var(--duration-fast) var(--ease-out);
-}
-
-.sidebar__link:hover {
-    background-color: var(--surface-2);
-    color: var(--text-primary);
-}
-
-.sidebar__link.is-active {
-    background-color: var(--accent-bg);
-    color: var(--accent-primary);
-}
-
-.sidebar__link-label {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--space-2);
-}
-
-.sidebar__link-icon {
-    width: 18px;
-    height: 18px;
-    display: inline-grid;
-    place-items: center;
-    font-size: 0.85rem;
-}
-
-.sidebar__count {
-    font-size: var(--text-xs);
-    color: var(--text-muted);
-    font-weight: 600;
-    background-color: var(--surface-2);
-    padding: 1px 8px;
-    border-radius: var(--radius-pill);
-}
-
-.sidebar__link.is-active .sidebar__count {
-    background-color: var(--accent-soft);
-    color: var(--accent-primary);
-}
-
-.sidebar__footer {
-    margin-top: auto;
-    padding: var(--space-4);
-    border-top: 1px solid var(--sidebar-border);
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: var(--space-2);
-}
-
-.sidebar__footer-links {
-    display: flex;
-    gap: var(--space-1);
-}
-
-/* Mobile sidebar — slide-over */
-.sidebar-scrim {
-    position: fixed;
-    inset: 0;
-    background-color: rgba(15, 23, 42, 0.4);
-    backdrop-filter: blur(2px);
-    z-index: 49;
-    opacity: 0;
-    pointer-events: none;
-    transition: opacity var(--duration-base) var(--ease-out);
-}
-
-body.sidebar-open .sidebar-scrim {
-    opacity: 1;
-    pointer-events: auto;
-}
 
 /* ============================================================
    Top bar
@@ -184,55 +15,51 @@ body.sidebar-open .sidebar-scrim {
     display: flex;
     align-items: center;
     gap: var(--space-3);
-    padding: var(--space-3) var(--space-6);
-    background-color: var(--header-bg);
-    backdrop-filter: saturate(180%) blur(10px);
-    -webkit-backdrop-filter: saturate(180%) blur(10px);
-    border-bottom: 1px solid var(--header-border);
-    min-height: 64px;
+    padding: var(--space-3) var(--space-5);
+    background-color: var(--bg-primary);
+    border-bottom: 1px solid var(--border-color);
+    min-height: 56px;
 }
 
-.top-bar__menu-btn {
-    display: none;
-    width: 40px;
-    height: 40px;
+.brand {
+    display: inline-flex;
     align-items: center;
-    justify-content: center;
-    border-radius: var(--radius-md);
-    border: 1px solid var(--border-color);
-    background-color: var(--surface-1);
-    color: var(--text-primary);
-    font-size: var(--text-base);
-}
-
-.top-bar__menu-btn:hover {
-    background-color: var(--surface-2);
-}
-
-.top-bar__title {
-    font-size: var(--text-md);
+    gap: var(--space-2);
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
     font-weight: 600;
     color: var(--text-primary);
+    letter-spacing: -0.01em;
+}
+
+.brand::before {
+    content: '~';
+    color: var(--accent);
+    font-weight: 700;
 }
 
 .top-bar__search {
     flex: 1;
-    max-width: 520px;
+    max-width: 480px;
     position: relative;
     margin-left: auto;
 }
 
 .top-bar__search-input {
     width: 100%;
-    height: 40px;
-    padding: 0 var(--space-9) 0 var(--space-9);
-    border-radius: var(--radius-md);
-    border: 1px solid var(--input-border);
-    background-color: var(--input-bg);
+    height: 34px;
+    padding: 0 var(--space-3) 0 var(--space-7);
+    border-radius: var(--radius-sm);
+    border: 1px solid var(--border-color);
+    background-color: var(--bg-primary);
     color: var(--text-primary);
+    font-family: var(--font-mono);
     font-size: var(--text-sm);
-    transition: border-color var(--duration-fast) var(--ease-out),
-                box-shadow var(--duration-fast) var(--ease-out);
+    transition: border-color var(--duration-fast) var(--ease-out);
+}
+
+.top-bar__search-input::placeholder {
+    color: var(--text-muted);
 }
 
 .top-bar__search-input:hover {
@@ -240,9 +67,9 @@ body.sidebar-open .sidebar-scrim {
 }
 
 .top-bar__search-input:focus {
-    outline: none;
-    border-color: var(--input-border-focus);
-    box-shadow: var(--focus-ring);
+    outline: 1px solid var(--text-primary);
+    outline-offset: -1px;
+    border-color: var(--text-primary);
 }
 
 .top-bar__search-icon {
@@ -252,15 +79,7 @@ body.sidebar-open .sidebar-scrim {
     transform: translateY(-50%);
     color: var(--text-muted);
     pointer-events: none;
-    font-size: var(--text-sm);
-}
-
-.top-bar__search-kbd {
-    position: absolute;
-    right: var(--space-3);
-    top: 50%;
-    transform: translateY(-50%);
-    pointer-events: none;
+    font-size: var(--text-xs);
 }
 
 .top-bar__search-clear {
@@ -268,59 +87,54 @@ body.sidebar-open .sidebar-scrim {
     right: var(--space-2);
     top: 50%;
     transform: translateY(-50%);
-    width: 24px;
-    height: 24px;
+    width: 22px;
+    height: 22px;
     display: grid;
     place-items: center;
-    border-radius: var(--radius-pill);
+    border-radius: var(--radius-sm);
     color: var(--text-muted);
+    font-size: var(--text-xs);
     background: transparent;
 }
 
 .top-bar__search-clear:hover {
-    background-color: var(--surface-3);
+    background-color: var(--surface-2);
     color: var(--text-primary);
 }
 
 .top-bar__actions {
     display: flex;
     align-items: center;
-    gap: var(--space-2);
+    gap: var(--space-1);
 }
 
 /* Theme toggle */
 .theme-toggle-btn {
-    width: 40px;
-    height: 40px;
+    width: 34px;
+    height: 34px;
     display: inline-grid;
     place-items: center;
-    border-radius: var(--radius-md);
-    border: 1px solid var(--border-color);
-    background-color: var(--surface-1);
-    color: var(--text-primary);
+    border-radius: var(--radius-sm);
+    border: 1px solid transparent;
+    background-color: transparent;
+    color: var(--text-secondary);
     transition: background-color var(--duration-fast) var(--ease-out),
-                border-color var(--duration-fast) var(--ease-out);
+                color var(--duration-fast) var(--ease-out);
 }
 
 .theme-toggle-btn:hover {
     background-color: var(--surface-2);
-    border-color: var(--border-strong);
+    color: var(--text-primary);
 }
 
 .theme-toggle-btn:focus-visible {
-    outline: none;
-    box-shadow: var(--focus-ring);
+    outline: 1px solid var(--text-primary);
+    outline-offset: 1px;
 }
 
 .theme-toggle-btn svg {
-    width: 18px;
-    height: 18px;
-}
-
-.theme-toggle-btn .icon-sun,
-.theme-toggle-btn .icon-moon {
-    transition: opacity var(--duration-base) var(--ease-out),
-                transform var(--duration-base) var(--ease-out);
+    width: 16px;
+    height: 16px;
 }
 
 .theme-toggle-btn .icon-sun { display: none; }
@@ -328,127 +142,191 @@ body.sidebar-open .sidebar-scrim {
 [data-theme="dark"] .theme-toggle-btn .icon-sun { display: block; }
 [data-theme="dark"] .theme-toggle-btn .icon-moon { display: none; }
 
+/* Tool-page back link */
+.top-bar__back {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    height: 34px;
+    padding: 0 var(--space-3) 0 var(--space-2);
+    border-radius: var(--radius-sm);
+    color: var(--text-secondary);
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+}
+
+.top-bar__back:hover {
+    background-color: var(--surface-2);
+    color: var(--text-primary);
+}
+
+.top-bar__crumb {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    color: var(--text-secondary);
+}
+
+.top-bar__crumb-sep {
+    color: var(--text-muted);
+}
+
+.top-bar__crumb-current {
+    color: var(--text-primary);
+}
+
 /* ============================================================
-   Content area (homepage)
+   Content
    ============================================================ */
 
 .content {
     flex: 1 0 auto;
-    padding: var(--space-7) var(--space-6) var(--space-9);
+    padding: var(--space-7) var(--space-5) var(--space-9);
 }
 
 .content__inner {
-    max-width: 1280px;
+    max-width: 1100px;
     margin: 0 auto;
 }
 
-.hero-strip {
-    display: flex;
-    align-items: flex-end;
-    justify-content: space-between;
-    flex-wrap: wrap;
-    gap: var(--space-4);
-    margin-bottom: var(--space-7);
-}
-
-.hero-strip__title {
-    font-size: var(--text-2xl);
-    line-height: 1.15;
-    letter-spacing: -0.02em;
-    margin-bottom: var(--space-1);
-}
-
-.hero-strip__subtitle {
-    color: var(--text-secondary);
+/* Intro line (terminal-style) */
+.intro {
+    font-family: var(--font-mono);
     font-size: var(--text-sm);
-    max-width: 540px;
-}
-
-.hero-strip__meta {
-    color: var(--text-muted);
-    font-size: var(--text-xs);
-}
-
-.hero-strip__meta a {
     color: var(--text-secondary);
+    margin-bottom: var(--space-8);
+    line-height: var(--leading-relaxed);
+}
+
+.intro__prompt {
+    color: var(--accent);
+    margin-right: var(--space-2);
+    user-select: none;
+}
+
+.intro__count {
+    color: var(--text-primary);
     font-weight: 500;
 }
 
-.hero-strip__meta a:hover {
-    color: var(--accent-primary);
+/* ============================================================
+   Category sections
+   ============================================================ */
+
+.section {
+    margin-bottom: var(--space-8);
+}
+
+.section[hidden] { display: none; }
+
+.section__header {
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-3);
+    margin-bottom: var(--space-4);
+    padding-bottom: var(--space-2);
+    border-bottom: 1px solid var(--border-color);
+}
+
+.section__index {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--text-muted);
+    font-weight: 500;
+}
+
+.section__title {
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-primary);
+}
+
+.section__count {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    color: var(--text-muted);
+    margin-left: auto;
 }
 
 /* ============================================================
-   Tool grid
+   Tool grid (dense)
    ============================================================ */
 
 .tool-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
-    gap: var(--space-5);
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 0;
+    border: 1px solid var(--border-color);
+    border-radius: var(--radius-md);
+    overflow: hidden;
+    background-color: var(--surface-1);
 }
 
 /* ============================================================
-   Tool card (new horizontal design)
+   Tool card — minimal, dense, no per-category color
    ============================================================ */
 
 .tool-card {
     position: relative;
     display: grid;
-    grid-template-columns: 52px 1fr;
-    gap: var(--space-4);
-    padding: var(--space-5);
+    grid-template-columns: 28px 1fr;
+    column-gap: var(--space-3);
+    align-items: start;
+    padding: var(--space-4) var(--space-4);
     background-color: var(--surface-1);
-    border: 1px solid var(--border-color);
-    border-left: 3px solid var(--cat-other);
-    border-radius: var(--radius-lg);
     color: var(--text-primary);
+    border-right: 1px solid var(--border-color);
+    border-bottom: 1px solid var(--border-color);
     cursor: pointer;
-    overflow: hidden;
-    transition: transform var(--duration-base) var(--ease-out),
-                box-shadow var(--duration-base) var(--ease-out),
-                border-color var(--duration-base) var(--ease-out),
-                background-color var(--duration-base) var(--ease-out);
+    transition: background-color var(--duration-fast) var(--ease-out);
 }
 
+.tool-card[hidden] { display: none; }
+
 .tool-card:hover {
-    transform: translateY(-2px);
-    box-shadow: var(--shadow-md);
-    border-color: var(--border-strong);
+    background-color: var(--surface-2);
 }
 
 .tool-card:focus-visible {
-    outline: none;
-    box-shadow: var(--focus-ring);
+    outline: 1px solid var(--text-primary);
+    outline-offset: -1px;
+    z-index: 1;
 }
 
 .tool-card__icon {
-    width: 48px;
-    height: 48px;
+    width: 22px;
+    height: 22px;
     display: grid;
     place-items: center;
-    border-radius: var(--radius-md);
-    background-color: var(--surface-2);
-    color: var(--accent-primary);
-    font-size: 1.4rem;
-    flex-shrink: 0;
+    color: var(--text-muted);
+    font-size: 0.95rem;
+    margin-top: 2px;
+    transition: color var(--duration-fast) var(--ease-out);
 }
 
-.tool-card__body {
-    min-width: 0;
+.tool-card:hover .tool-card__icon {
+    color: var(--accent);
 }
+
+.tool-card__body { min-width: 0; }
 
 .tool-card__title {
-    font-family: var(--font-display);
-    font-size: var(--text-md);
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
     font-weight: 600;
     color: var(--text-primary);
     margin: 0 0 var(--space-1);
-    line-height: 1.25;
+    line-height: 1.3;
     overflow-wrap: break-word;
 }
 
 .tool-card__desc {
+    font-family: var(--font-sans);
     font-size: var(--text-xs);
     color: var(--text-secondary);
     line-height: var(--leading-normal);
@@ -459,64 +337,24 @@ body.sidebar-open .sidebar-scrim {
     overflow: hidden;
 }
 
-.tool-card__chip {
-    margin-top: var(--space-3);
-}
-
-/* Category accents on cards */
-.tool-card[data-category="text"]        { border-left-color: var(--cat-text); }
-.tool-card[data-category="encoding"]    { border-left-color: var(--cat-encoding); }
-.tool-card[data-category="data format"] { border-left-color: var(--cat-data); }
-.tool-card[data-category="web"]         { border-left-color: var(--cat-web); }
-.tool-card[data-category="crypto"]      { border-left-color: var(--cat-crypto); }
-.tool-card[data-category="time"]        { border-left-color: var(--cat-time); }
-.tool-card[data-category="visual"]      { border-left-color: var(--cat-visual); }
-.tool-card[data-category="api"]         { border-left-color: var(--cat-api); }
-.tool-card[data-category="network"]     { border-left-color: var(--cat-network); }
-
-.tool-card[data-category="text"]        .tool-card__icon { color: var(--cat-text); }
-.tool-card[data-category="encoding"]    .tool-card__icon { color: var(--cat-encoding); }
-.tool-card[data-category="data format"] .tool-card__icon { color: var(--cat-data); }
-.tool-card[data-category="web"]         .tool-card__icon { color: var(--cat-web); }
-.tool-card[data-category="crypto"]      .tool-card__icon { color: var(--cat-crypto); }
-.tool-card[data-category="time"]        .tool-card__icon { color: var(--cat-time); }
-.tool-card[data-category="visual"]      .tool-card__icon { color: var(--cat-visual); }
-.tool-card[data-category="api"]         .tool-card__icon { color: var(--cat-api); }
-.tool-card[data-category="network"]     .tool-card__icon { color: var(--cat-network); }
-
-/* ============================================================
-   No results state
-   ============================================================ */
-
-.empty-state {
-    grid-column: 1 / -1;
-    text-align: center;
-    padding: var(--space-9) var(--space-6);
-    color: var(--text-muted);
-}
-
-.empty-state__icon {
-    font-size: 2rem;
-    margin-bottom: var(--space-3);
-    color: var(--text-muted);
-}
-
-.empty-state__title {
-    font-size: var(--text-md);
-    color: var(--text-primary);
-    margin-bottom: var(--space-2);
-}
-
+/* No results */
 .no-results-message {
+    padding: var(--space-9) var(--space-5);
     text-align: center;
-    padding: var(--space-9) var(--space-6);
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
     color: var(--text-muted);
-    font-size: var(--text-md);
+    border: 1px dashed var(--border-color);
+    border-radius: var(--radius-md);
+}
+
+.no-results-message::before {
+    content: '$ ';
+    color: var(--accent);
 }
 
 /* ============================================================
    Tool page layout
-   Used by tool/*.html pages (no sidebar — minimal top bar)
    ============================================================ */
 
 .tool-page-shell {
@@ -525,40 +363,16 @@ body.sidebar-open .sidebar-scrim {
     min-height: 100vh;
 }
 
-.tool-page-shell .top-bar {
-    justify-content: flex-start;
-}
-
-.tool-page-shell .top-bar__back {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--space-2);
-    height: 40px;
-    padding: 0 var(--space-3);
-    border-radius: var(--radius-md);
-    color: var(--text-secondary);
-    font-size: var(--text-sm);
-    font-weight: 500;
-    transition: background-color var(--duration-fast) var(--ease-out),
-                color var(--duration-fast) var(--ease-out);
-}
-
-.tool-page-shell .top-bar__back:hover {
-    background-color: var(--surface-2);
-    color: var(--text-primary);
-}
-
 .tool-container {
     flex: 1 0 auto;
-    padding: var(--space-7) var(--space-6) var(--space-9);
+    padding: var(--space-7) var(--space-5) var(--space-9);
 }
 
 .tool-container .container {
-    max-width: 1100px;
+    max-width: 980px;
 }
 
 .tool-header {
-    text-align: center;
     margin-bottom: var(--space-4);
 }
 
@@ -569,10 +383,10 @@ body.sidebar-open .sidebar-scrim {
 
 .tool-description {
     max-width: 720px;
-    margin: 0 auto var(--space-7);
-    text-align: center;
+    margin: 0 0 var(--space-7);
     color: var(--text-secondary);
     font-size: var(--text-sm);
+    line-height: var(--leading-relaxed);
 }
 
 /* ============================================================
@@ -582,102 +396,77 @@ body.sidebar-open .sidebar-scrim {
 .app-footer,
 footer {
     flex-shrink: 0;
-    padding: var(--space-6) var(--space-6);
+    padding: var(--space-5);
     border-top: 1px solid var(--border-color);
-    background-color: var(--surface-1);
-    text-align: center;
+    background-color: var(--bg-primary);
     color: var(--text-muted);
+    font-family: var(--font-mono);
     font-size: var(--text-xs);
+}
+
+.app-footer__inner {
+    max-width: 1100px;
+    margin: 0 auto;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: var(--space-2);
 }
 
 .app-footer p,
 footer p {
-    margin: 0 0 var(--space-1);
+    margin: 0;
     color: var(--text-muted);
 }
 
 .app-footer a,
 footer a {
     color: var(--text-secondary);
-    font-weight: 500;
-    margin: 0 var(--space-1);
 }
 
 .app-footer a:hover,
 footer a:hover {
-    color: var(--accent-primary);
+    color: var(--text-primary);
 }
 
-/* ============================================================
-   Legacy homepage tools-grid alias
-   (kept so index.html works if not fully migrated)
-   ============================================================ */
+/* Legacy footer .container override */
+footer .container {
+    text-align: center;
+}
 
+/* Legacy tools-grid alias (still used by some pages) */
 .tools-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
-    gap: var(--space-5);
+    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: var(--space-4);
 }
 
 /* ============================================================
-   Responsive breakpoints
+   Responsive
    ============================================================ */
 
-@media (max-width: 1024px) {
-    .app-shell {
-        grid-template-columns: 220px 1fr;
-    }
-    .tool-grid,
-    .tools-grid {
-        grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-    }
-}
-
 @media (max-width: 768px) {
-    .app-shell {
-        grid-template-columns: 1fr;
-    }
-    .sidebar {
-        position: fixed;
-        top: 0;
-        left: 0;
-        height: 100vh;
-        width: 280px;
-        max-width: 80vw;
-        transform: translateX(-100%);
-        transition: transform var(--duration-base) var(--ease-out);
-        box-shadow: var(--shadow-lg);
-    }
-    body.sidebar-open .sidebar {
-        transform: translateX(0);
-    }
     .top-bar {
         padding: var(--space-3) var(--space-4);
+        gap: var(--space-2);
     }
-    .top-bar__menu-btn {
-        display: inline-grid;
-    }
+    .top-bar__search { max-width: none; }
     .content {
-        padding: var(--space-6) var(--space-4) var(--space-7);
-    }
-    .tool-grid,
-    .tools-grid {
-        grid-template-columns: 1fr;
-    }
-    .hero-strip {
-        flex-direction: column;
-        align-items: flex-start;
+        padding: var(--space-5) var(--space-4) var(--space-7);
     }
     .tool-container {
-        padding: var(--space-6) var(--space-4) var(--space-7);
+        padding: var(--space-5) var(--space-4) var(--space-7);
+    }
+    .tool-grid {
+        grid-template-columns: 1fr;
+    }
+    .app-footer__inner {
+        justify-content: center;
+        text-align: center;
     }
 }
 
 @media (max-width: 480px) {
-    .top-bar__search-kbd {
-        display: none;
-    }
-    .top-bar__title {
-        display: none;
-    }
+    .top-bar__back span { display: none; }
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,105 +1,79 @@
 /* ============================================================
-   Devtools — Base styles & design tokens
-   This file contains only design tokens, resets, and base
-   typography. Layout lives in layout.css, components in
-   components.css, theme colours in theme.css.
+   Devtools — base styles & design tokens
+   Terminal-flavoured: mono-forward, dense, minimal chrome.
    ============================================================ */
 
 :root {
-    /* Fonts */
-    --font-display: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-    --font-body: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-    --font-mono: 'JetBrains Mono', 'Fira Code', ui-monospace, SFMono-Regular, Menlo, Consolas, 'Courier New', monospace;
+    /* Fonts — mono is the primary identity */
+    --font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    --font-sans: -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', Roboto, sans-serif;
+    --font-display: var(--font-mono);
+    --font-body: var(--font-sans);
+    --font-primary: var(--font-sans); /* legacy alias */
 
-    /* Type scale */
+    /* Type scale (tighter) */
     --text-xs: 0.75rem;     /* 12 */
-    --text-sm: 0.875rem;    /* 14 */
-    --text-base: 1rem;      /* 16 */
-    --text-md: 1.0625rem;   /* 17 */
-    --text-lg: 1.25rem;     /* 20 */
-    --text-xl: 1.5rem;      /* 24 */
-    --text-2xl: 2rem;       /* 32 */
-    --text-3xl: 2.5rem;     /* 40 */
-    --text-4xl: 3rem;       /* 48 */
+    --text-sm: 0.8125rem;   /* 13 */
+    --text-base: 0.9375rem; /* 15 */
+    --text-md: 1rem;        /* 16 */
+    --text-lg: 1.125rem;    /* 18 */
+    --text-xl: 1.375rem;    /* 22 */
+    --text-2xl: 1.75rem;    /* 28 */
+    --text-3xl: 2.25rem;    /* 36 */
     --leading-tight: 1.25;
-    --leading-normal: 1.55;
-    --leading-relaxed: 1.7;
+    --leading-normal: 1.5;
+    --leading-relaxed: 1.65;
 
-    /* Spacing scale (4px base) */
+    /* Spacing (4px base, denser scale) */
     --space-0: 0;
-    --space-1: 0.25rem;     /* 4 */
-    --space-2: 0.5rem;      /* 8 */
-    --space-3: 0.75rem;     /* 12 */
-    --space-4: 1rem;        /* 16 */
-    --space-5: 1.25rem;     /* 20 */
-    --space-6: 1.5rem;      /* 24 */
-    --space-7: 2rem;        /* 32 */
-    --space-8: 2.5rem;      /* 40 */
-    --space-9: 3rem;        /* 48 */
-    --space-10: 4rem;       /* 64 */
+    --space-1: 0.25rem;
+    --space-2: 0.5rem;
+    --space-3: 0.75rem;
+    --space-4: 1rem;
+    --space-5: 1.25rem;
+    --space-6: 1.5rem;
+    --space-7: 2rem;
+    --space-8: 2.5rem;
+    --space-9: 3rem;
+    --space-10: 4rem;
 
-    /* Legacy spacing aliases (keep existing tools working) */
+    /* Legacy aliases */
     --spacing-xs: var(--space-1);
     --spacing-sm: var(--space-2);
     --spacing-md: var(--space-4);
-    --spacing-lg: var(--space-6);
-    --spacing-xl: var(--space-7);
-    --spacing-xxl: var(--space-9);
+    --spacing-lg: var(--space-5);
+    --spacing-xl: var(--space-6);
+    --spacing-xxl: var(--space-8);
 
-    /* Radius scale */
-    --radius-sm: 6px;
-    --radius-md: 10px;
-    --radius-lg: 14px;
-    --radius-xl: 20px;
-    --radius-pill: 999px;
-    --border-radius: var(--radius-md); /* legacy alias */
+    /* Radius — sharper. Just three. */
+    --radius-sm: 3px;
+    --radius-md: 6px;
+    --radius-lg: 8px;
+    --border-radius: var(--radius-md); /* legacy */
 
-    /* Shadow scale */
-    --shadow-xs: 0 1px 2px rgba(15, 23, 42, 0.04);
-    --shadow-sm: 0 1px 3px rgba(15, 23, 42, 0.06), 0 1px 2px rgba(15, 23, 42, 0.04);
-    --shadow-md: 0 4px 8px rgba(15, 23, 42, 0.06), 0 2px 4px rgba(15, 23, 42, 0.04);
-    --shadow-lg: 0 12px 24px rgba(15, 23, 42, 0.08), 0 4px 8px rgba(15, 23, 42, 0.04);
-    --shadow-xl: 0 24px 48px rgba(15, 23, 42, 0.12), 0 8px 16px rgba(15, 23, 42, 0.06);
+    /* Shadows — keep only two */
+    --shadow-sm: 0 1px 0 rgba(0, 0, 0, 0.04);
+    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
 
     /* Motion */
-    --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
-    --ease-in-out: cubic-bezier(0.65, 0, 0.35, 1);
-    --duration-fast: 120ms;
-    --duration-base: 200ms;
-    --duration-slow: 320ms;
-    --transition-speed: var(--duration-base); /* legacy alias */
+    --ease-out: cubic-bezier(0.2, 0, 0, 1);
+    --duration-fast: 100ms;
+    --duration-base: 160ms;
+    --transition-speed: var(--duration-base);
 
     /* Focus ring */
-    --focus-ring: 0 0 0 3px var(--accent-soft, rgba(59, 130, 246, 0.35));
-
-    /* Breakpoints (exposed for JS) */
-    --bp-sm: 480px;
-    --bp-md: 768px;
-    --bp-lg: 1024px;
-    --bp-xl: 1280px;
+    --focus-ring: 0 0 0 2px var(--bg-primary), 0 0 0 4px var(--accent);
 }
 
 /* ============================================================
    Reset
    ============================================================ */
 
-*, *::before, *::after {
-    box-sizing: border-box;
-}
+*, *::before, *::after { box-sizing: border-box; }
+* { margin: 0; padding: 0; }
 
-* {
-    margin: 0;
-    padding: 0;
-}
-
-html {
-    -webkit-text-size-adjust: 100%;
-    text-size-adjust: 100%;
-}
-
-html, body {
-    height: 100%;
-}
+html { -webkit-text-size-adjust: 100%; text-size-adjust: 100%; }
+html, body { height: 100%; }
 
 body {
     font-family: var(--font-body);
@@ -110,58 +84,32 @@ body {
     display: flex;
     flex-direction: column;
     min-height: 100vh;
-    transition: background-color var(--duration-base) var(--ease-out),
-                color var(--duration-base) var(--ease-out);
+    background-color: var(--bg-primary);
+    color: var(--text-primary);
+    transition: background-color var(--duration-fast) var(--ease-out),
+                color var(--duration-fast) var(--ease-out);
 }
 
-a {
-    color: inherit;
-    text-decoration: none;
-    transition: color var(--duration-fast) var(--ease-out);
-}
+a { color: inherit; text-decoration: none; }
+button { cursor: pointer; font-family: inherit; font-size: inherit; border: 0; background: transparent; color: inherit; }
+input, textarea, select { font-family: inherit; font-size: inherit; color: inherit; }
+ul { list-style: none; }
+img, svg { display: block; max-width: 100%; }
 
-button {
-    cursor: pointer;
-    font-family: inherit;
-    font-size: inherit;
-    border: 0;
-    background: transparent;
-    color: inherit;
-}
-
-input, textarea, select {
-    font-family: inherit;
-    font-size: inherit;
-    color: inherit;
-}
-
-ul {
-    list-style: none;
-}
-
-img, svg {
-    display: block;
-    max-width: 100%;
-}
-
-/* Skip link for accessibility */
+/* Skip link */
 .skip-link {
     position: absolute;
     top: -40px;
     left: var(--space-4);
-    padding: var(--space-2) var(--space-4);
-    background: var(--accent-primary);
-    color: #fff;
-    border-radius: var(--radius-md);
+    padding: var(--space-2) var(--space-3);
+    background: var(--accent);
+    color: var(--accent-on);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    border-radius: var(--radius-sm);
     z-index: 1000;
-    transition: top var(--duration-fast) var(--ease-out);
 }
-
-.skip-link:focus {
-    top: var(--space-2);
-    outline: none;
-    box-shadow: var(--focus-ring);
-}
+.skip-link:focus { top: var(--space-2); outline: none; }
 
 /* ============================================================
    Typography
@@ -172,103 +120,66 @@ h1, h2, h3, h4, h5, h6 {
     line-height: var(--leading-tight);
     color: var(--text-primary);
     letter-spacing: -0.01em;
-    font-weight: 700;
+    font-weight: 600;
 }
 
-h1 { font-size: var(--text-3xl); }
-h2 { font-size: var(--text-2xl); }
-h3 { font-size: var(--text-lg); font-weight: 600; }
-h4 { font-size: var(--text-md); font-weight: 600; }
-h5 { font-size: var(--text-base); font-weight: 600; }
-h6 { font-size: var(--text-sm); font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; }
+h1 { font-size: var(--text-2xl); }
+h2 { font-size: var(--text-xl); }
+h3 { font-size: var(--text-lg); }
+h4 { font-size: var(--text-md); }
+h5 { font-size: var(--text-base); }
+h6 { font-size: var(--text-xs); text-transform: uppercase; letter-spacing: 0.08em; }
 
-p {
-    color: var(--text-secondary);
-}
+p { color: var(--text-secondary); }
 
-code, pre {
+code, pre, kbd, samp {
     font-family: var(--font-mono);
-    font-size: 0.95em;
 }
 
 ::selection {
-    background-color: var(--selection-bg);
-    color: var(--selection-text);
+    background-color: var(--accent);
+    color: var(--accent-on);
 }
 
-/* ============================================================
-   Scrollbar
-   ============================================================ */
-
-::-webkit-scrollbar {
-    width: 10px;
-    height: 10px;
-}
-
-::-webkit-scrollbar-track {
-    background: var(--scrollbar-track);
-}
-
+/* Scrollbar */
+::-webkit-scrollbar { width: 10px; height: 10px; }
+::-webkit-scrollbar-track { background: transparent; }
 ::-webkit-scrollbar-thumb {
-    background: var(--scrollbar-thumb);
-    border-radius: var(--radius-pill);
-    border: 2px solid var(--scrollbar-track);
+    background: var(--border-color);
+    border-radius: 5px;
+    border: 2px solid var(--bg-primary);
 }
-
-::-webkit-scrollbar-thumb:hover {
-    background: var(--scrollbar-thumb-hover);
-}
+::-webkit-scrollbar-thumb:hover { background: var(--border-strong); }
 
 /* ============================================================
-   Utility classes
+   Utility classes (kept small)
    ============================================================ */
 
 .hidden { display: none !important; }
 .sr-only {
     position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
+    width: 1px; height: 1px;
+    padding: 0; margin: -1px;
     overflow: hidden;
     clip: rect(0, 0, 0, 0);
     white-space: nowrap;
     border: 0;
 }
+.text-mono { font-family: var(--font-mono); }
+.text-muted { color: var(--text-muted); }
 
-.flex { display: flex; }
-.flex-column { flex-direction: column; }
-.justify-between { justify-content: space-between; }
-.align-center { align-items: center; }
-.text-center { text-align: center; }
-.text-muted { color: var(--text-secondary); }
-
-.mt-1 { margin-top: var(--space-2); }
-.mt-2 { margin-top: var(--space-4); }
-.mt-3 { margin-top: var(--space-6); }
-.mt-4 { margin-top: var(--space-7); }
-.mb-1 { margin-bottom: var(--space-2); }
-.mb-2 { margin-bottom: var(--space-4); }
-.mb-3 { margin-bottom: var(--space-6); }
-.mb-4 { margin-bottom: var(--space-7); }
-
-/* Reduced motion */
 @media (prefers-reduced-motion: reduce) {
     *, *::before, *::after {
         animation-duration: 0.01ms !important;
         animation-iteration-count: 1 !important;
         transition-duration: 0.01ms !important;
-        scroll-behavior: auto !important;
     }
 }
 
-/* ============================================================
-   Container (legacy — used on tool pages without app-shell)
-   ============================================================ */
-
+/* Container — used by tool pages */
 .container {
     width: 100%;
-    max-width: 1200px;
+    max-width: 1100px;
     margin: 0 auto;
-    padding: 0 var(--space-4);
+    padding: 0 var(--space-5);
 }

--- a/css/theme.css
+++ b/css/theme.css
@@ -1,213 +1,118 @@
 /* ============================================================
-   Devtools — Theme (colour palette + theme-driven styling)
+   Devtools — theme (palette only)
+   One accent. Three surfaces. Real contrast. No gradients.
    ============================================================ */
 
 :root {
-    /* Neutral scale — light */
-    --neutral-50: #f8fafc;
-    --neutral-100: #f1f5f9;
-    --neutral-200: #e2e8f0;
-    --neutral-300: #cbd5e1;
-    --neutral-400: #94a3b8;
-    --neutral-500: #64748b;
-    --neutral-600: #475569;
-    --neutral-700: #334155;
-    --neutral-800: #1e293b;
-    --neutral-900: #0f172a;
-
     /* Surfaces */
-    --bg-primary: var(--neutral-50);
+    --bg-primary: #fafaf9;
     --bg-secondary: #ffffff;
-    --bg-tertiary: var(--neutral-100);
+    --bg-tertiary: #f4f4f2;
     --surface-1: #ffffff;
-    --surface-2: var(--neutral-50);
-    --surface-3: var(--neutral-100);
-    --surface-raised: #ffffff;
+    --surface-2: #f4f4f2;
+    --surface-3: #eceae6;
 
     /* Text */
-    --text-primary: var(--neutral-900);
-    --text-secondary: var(--neutral-600);
-    --text-muted: var(--neutral-500);
-    --text-on-accent: #ffffff;
+    --text-primary: #0a0a0a;
+    --text-secondary: #525252;
+    --text-muted: #8a8a87;
 
-    /* Borders */
-    --border-color: var(--neutral-200);
-    --border-strong: var(--neutral-300);
+    /* Border */
+    --border-color: #e7e5e0;
+    --border-strong: #d4d2cd;
 
-    /* Accent (brand) */
-    --accent-primary: #3b82f6;
-    --accent-secondary: #2563eb;
-    --accent-strong: #1d4ed8;
-    --accent-soft: rgba(59, 130, 246, 0.18);
-    --accent-bg: rgba(59, 130, 246, 0.08);
-    --primary-color: var(--accent-primary);          /* legacy */
-    --primary-color-rgb: 59, 130, 246;                /* legacy */
+    /* Accent — a single warm sharp color (not Tailwind blue) */
+    --accent: #ff5b1f;        /* deliberate vermilion */
+    --accent-hover: #e64d12;
+    --accent-on: #ffffff;
+    --accent-soft: rgba(255, 91, 31, 0.10);
+
+    /* Legacy aliases used by tool pages */
+    --accent-primary: var(--accent);
+    --accent-secondary: var(--accent-hover);
+    --primary-color: var(--accent);
+    --primary-color-rgb: 255, 91, 31;
 
     /* Semantic */
-    --success: #16a34a;
-    --success-bg: #dcfce7;
+    --success: #15803d;
+    --success-bg: #ecfccb;
     --success-text: #166534;
-    --warning: #d97706;
-    --warning-bg: #fef3c7;
-    --warning-text: #92400e;
-    --danger: #dc2626;
+    --danger: #b91c1c;
     --error-bg: #fee2e2;
-    --error-text: #b91c1c;
-    --info: #0284c7;
-    --info-bg: #e0f2fe;
-    --info-text: #075985;
+    --error-text: #991b1b;
 
-    /* Category accents — each tool category gets a hue */
-    --cat-text: #f97316;       /* orange */
-    --cat-encoding: #10b981;   /* emerald */
-    --cat-data: #6366f1;       /* indigo */
-    --cat-web: #06b6d4;        /* cyan */
-    --cat-crypto: #ef4444;     /* red */
-    --cat-time: #f59e0b;       /* amber */
-    --cat-visual: #ec4899;     /* pink */
-    --cat-api: #8b5cf6;        /* violet */
-    --cat-network: #14b8a6;    /* teal */
-    --cat-other: var(--neutral-400);
-
-    /* Inputs / forms */
+    /* Inputs */
     --input-bg: #ffffff;
-    --input-border: var(--neutral-200);
-    --input-border-hover: var(--neutral-300);
-    --input-border-focus: var(--accent-primary);
+    --input-border: #d4d2cd;
+    --input-border-hover: #a8a6a0;
+    --input-border-focus: var(--accent);
+    --input-border-focus: var(--text-primary);
 
-    /* Buttons (legacy gradients kept as fallback) */
-    --button-bg: var(--accent-primary);
-    --button-bg-hover: var(--accent-secondary);
+    /* Buttons (legacy) */
+    --button-bg: var(--text-primary);
     --button-text: #ffffff;
-    --button-hover: var(--accent-secondary);
+    --button-hover: #262626;
 
-    /* Code blocks */
-    --code-bg: var(--neutral-100);
-    --code-text: var(--neutral-800);
+    /* Code */
+    --code-bg: #f4f4f2;
+    --code-text: var(--text-primary);
 
-    /* Header / sidebar */
-    --header-bg: rgba(255, 255, 255, 0.85);
-    --header-border: var(--neutral-200);
-    --sidebar-bg: #ffffff;
-    --sidebar-border: var(--neutral-200);
-
-    /* Scrollbar */
-    --scrollbar-track: transparent;
-    --scrollbar-thumb: var(--neutral-300);
-    --scrollbar-thumb-hover: var(--neutral-400);
-
-    /* Selection */
-    --selection-bg: rgba(59, 130, 246, 0.22);
-    --selection-text: var(--neutral-900);
+    /* Selection / scrollbar */
+    --selection-bg: var(--text-primary);
+    --selection-text: var(--bg-primary);
 }
-
-/* ============================================================
-   Dark theme
-   ============================================================ */
 
 [data-theme="dark"] {
-    --neutral-50: #f8fafc;
-    --neutral-100: #e2e8f0;
-    --neutral-200: #cbd5e1;
-    --neutral-300: #94a3b8;
-    --neutral-400: #64748b;
-    --neutral-500: #475569;
-    --neutral-600: #334155;
-    --neutral-700: #1e293b;
-    --neutral-800: #0f172a;
-    --neutral-900: #020617;
+    --bg-primary: #0d0d0c;
+    --bg-secondary: #121211;
+    --bg-tertiary: #1a1a18;
+    --surface-1: #121211;
+    --surface-2: #1a1a18;
+    --surface-3: #232320;
 
-    --bg-primary: #0b0f17;
-    --bg-secondary: #11151f;
-    --bg-tertiary: #161b27;
-    --surface-1: #11151f;
-    --surface-2: #161b27;
-    --surface-3: #1c2230;
-    --surface-raised: #1a1f2c;
+    --text-primary: #f5f5f1;
+    --text-secondary: #a8a6a0;
+    --text-muted: #6f6e69;
 
-    --text-primary: #f1f5f9;
-    --text-secondary: #b8c0cc;
-    --text-muted: #8a93a3;
-    --text-on-accent: #ffffff;
+    --border-color: #232320;
+    --border-strong: #34332e;
 
-    --border-color: #232a38;
-    --border-strong: #2e3647;
+    --accent: #ff7042;
+    --accent-hover: #ff8a62;
+    --accent-on: #0d0d0c;
+    --accent-soft: rgba(255, 112, 66, 0.12);
 
-    --accent-primary: #60a5fa;
-    --accent-secondary: #3b82f6;
-    --accent-strong: #2563eb;
-    --accent-soft: rgba(96, 165, 250, 0.22);
-    --accent-bg: rgba(96, 165, 250, 0.10);
-    --primary-color: var(--accent-primary);
-    --primary-color-rgb: 96, 165, 250;
+    --accent-primary: var(--accent);
+    --accent-secondary: var(--accent-hover);
+    --primary-color: var(--accent);
+    --primary-color-rgb: 255, 112, 66;
 
-    --success: #22c55e;
-    --success-bg: rgba(34, 197, 94, 0.12);
+    --success: #4ade80;
+    --success-bg: rgba(74, 222, 128, 0.12);
     --success-text: #86efac;
-    --warning: #f59e0b;
-    --warning-bg: rgba(245, 158, 11, 0.12);
-    --warning-text: #fcd34d;
-    --danger: #ef4444;
-    --error-bg: rgba(239, 68, 68, 0.12);
+    --danger: #f87171;
+    --error-bg: rgba(248, 113, 113, 0.12);
     --error-text: #fca5a5;
-    --info: #38bdf8;
-    --info-bg: rgba(56, 189, 248, 0.12);
-    --info-text: #7dd3fc;
 
-    /* Category accents tweaked for dark mode */
-    --cat-text: #fb923c;
-    --cat-encoding: #34d399;
-    --cat-data: #818cf8;
-    --cat-web: #22d3ee;
-    --cat-crypto: #f87171;
-    --cat-time: #fbbf24;
-    --cat-visual: #f472b6;
-    --cat-api: #a78bfa;
-    --cat-network: #2dd4bf;
-    --cat-other: #64748b;
+    --input-bg: #121211;
+    --input-border: #2a2a26;
+    --input-border-hover: #3a3935;
+    --input-border-focus: var(--text-primary);
 
-    --input-bg: #161b27;
-    --input-border: #2a3142;
-    --input-border-hover: #3a4356;
-    --input-border-focus: var(--accent-primary);
+    --button-bg: var(--text-primary);
+    --button-text: #0d0d0c;
+    --button-hover: #e7e5e0;
 
-    --button-bg: var(--accent-primary);
-    --button-bg-hover: var(--accent-secondary);
-    --button-text: #0b0f17;
-    --button-hover: var(--accent-secondary);
+    --code-bg: #1a1a18;
+    --code-text: var(--text-primary);
 
-    --code-bg: #161b27;
-    --code-text: #e6edf6;
-
-    --header-bg: rgba(11, 15, 23, 0.85);
-    --header-border: #1f2533;
-    --sidebar-bg: #11151f;
-    --sidebar-border: #1f2533;
-
-    --scrollbar-track: transparent;
-    --scrollbar-thumb: #2a3142;
-    --scrollbar-thumb-hover: #3a4356;
-
-    --selection-bg: rgba(96, 165, 250, 0.32);
-    --selection-text: #ffffff;
+    --selection-bg: var(--accent);
+    --selection-text: var(--accent-on);
 }
 
-/* ============================================================
-   Base theme application
-   ============================================================ */
-
-body {
-    background-color: var(--bg-primary);
-    color: var(--text-primary);
-}
-
-a {
-    color: var(--accent-primary);
-}
-
-a:hover {
-    color: var(--accent-secondary);
-}
+/* Theme application */
+a { color: var(--accent); }
+a:hover { color: var(--accent-hover); }
 
 hr {
     border: 0;
@@ -215,16 +120,15 @@ hr {
     margin: var(--space-6) 0;
 }
 
-/* Form element theming */
+/* Native form element baseline */
 textarea, input[type="text"], input[type="number"], input[type="search"],
 input[type="password"], input[type="email"], input[type="url"], select {
     background-color: var(--input-bg);
     border: 1px solid var(--input-border);
     color: var(--text-primary);
-    border-radius: var(--radius-md);
+    border-radius: var(--radius-sm);
     padding: var(--space-2) var(--space-3);
-    transition: border-color var(--duration-fast) var(--ease-out),
-                box-shadow var(--duration-fast) var(--ease-out);
+    transition: border-color var(--duration-fast) var(--ease-out);
 }
 
 textarea:hover, input[type="text"]:hover, input[type="number"]:hover,
@@ -236,16 +140,17 @@ input[type="email"]:hover, input[type="url"]:hover, select:hover {
 textarea:focus, input[type="text"]:focus, input[type="number"]:focus,
 input[type="search"]:focus, input[type="password"]:focus,
 input[type="email"]:focus, input[type="url"]:focus, select:focus {
-    border-color: var(--input-border-focus);
-    box-shadow: var(--focus-ring);
-    outline: none;
+    border-color: var(--text-primary);
+    box-shadow: none;
+    outline: 1px solid var(--text-primary);
+    outline-offset: -1px;
 }
 
 textarea {
     font-family: var(--font-mono);
     line-height: var(--leading-normal);
     resize: vertical;
-    min-height: 150px;
+    min-height: 160px;
     padding: var(--space-3);
 }
 
@@ -257,8 +162,8 @@ pre, code {
 }
 
 code {
-    padding: 0.1em 0.4em;
-    font-size: 0.9em;
+    padding: 0.1em 0.35em;
+    font-size: 0.92em;
 }
 
 pre {

--- a/index.html
+++ b/index.html
@@ -3,9 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Devtools - A comprehensive collection of web-based tools for developers">
-    <meta name="theme-color" content="#0b0f17">
-    <title>Devtools — Developer Tools</title>
+    <meta name="description" content="A collection of fast, offline-friendly developer utilities.">
+    <meta name="theme-color" content="#0d0d0c">
+    <title>devtools</title>
     <link rel="stylesheet" href="css/styles.css">
     <link rel="stylesheet" href="css/theme.css">
     <link rel="stylesheet" href="css/layout.css">
@@ -15,387 +15,392 @@
     <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <meta property="og:title" content="Devtools — Developer Tools">
-    <meta property="og:description" content="A comprehensive collection of web-based tools for developers">
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="https://irfansofyana.github.io/Devtools/">
 </head>
 <body>
-    <a class="skip-link" href="#main-content">Skip to content</a>
+    <a class="skip-link" href="#tools">Skip to content</a>
 
-    <div class="app-shell">
-        <aside class="sidebar" id="sidebar" aria-label="Primary navigation">
-            <a class="sidebar__brand" href="index.html">
-                <span class="sidebar__brand-mark" aria-hidden="true">
-                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg>
-                </span>
-                Devtools
-            </a>
-
-            <div class="sidebar__section">
-                <div class="sidebar__heading">Browse</div>
-                <nav class="sidebar__nav" id="category-nav" aria-label="Categories">
-                    <!-- Populated by js/search.js -->
-                </nav>
-            </div>
-
-            <div class="sidebar__footer">
-                <div class="sidebar__footer-links">
-                    <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
-                        <i class="fab fa-github" aria-hidden="true"></i>
-                    </a>
-                    <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools/issues" target="_blank" rel="noopener" aria-label="Report an issue">
-                        <i class="fas fa-comment-dots" aria-hidden="true"></i>
-                    </a>
-                </div>
-                <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
-                    <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
-                    <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
-                </button>
-            </div>
-        </aside>
-
-        <div class="sidebar-scrim" id="sidebar-scrim" aria-hidden="true"></div>
-
-        <div class="app-main">
-            <header class="top-bar">
-                <button class="top-bar__menu-btn" id="sidebar-toggle" aria-label="Open menu" aria-controls="sidebar" aria-expanded="false">
-                    <i class="fas fa-bars" aria-hidden="true"></i>
-                </button>
-                <div class="top-bar__title">All Tools</div>
-                <div class="top-bar__search">
-                    <i class="fas fa-search top-bar__search-icon" aria-hidden="true"></i>
-                    <input type="search" id="tool-search" class="top-bar__search-input" placeholder="Search tools…" aria-label="Search tools" autocomplete="off">
-                    <button type="button" id="search-clear" class="top-bar__search-clear hidden" aria-label="Clear search">
-                        <i class="fas fa-times" aria-hidden="true"></i>
-                    </button>
-                    <span class="top-bar__search-kbd"><kbd class="kbd">⌘</kbd> <kbd class="kbd">K</kbd></span>
-                </div>
-                <div class="top-bar__actions"></div>
-            </header>
-
-            <main class="content" id="main-content">
-                <div class="content__inner">
-                    <section class="hero-strip">
-                        <div>
-                            <h1 class="hero-strip__title">Developer Tools</h1>
-                            <p class="hero-strip__subtitle">A collection of fast, offline-friendly utilities for everyday developer tasks.</p>
-                        </div>
-                        <div class="hero-strip__meta">
-                            <span id="tool-count">36 tools</span> · Built by
-                            <a href="https://github.com/irfansofyana" target="_blank" rel="noopener">irfansofyana</a>
-                        </div>
-                    </section>
-
-                    <div class="tool-grid" id="tools-grid">
-                        <a href="tools/api-mock-generator.html" class="tool-card" data-category="api">
-                            <div class="tool-card__icon"><i class="fas fa-vial" aria-hidden="true"></i></div>
-                            <div class="tool-card__body">
-                                <h3 class="tool-card__title">API Mock Data Generator</h3>
-                                <p class="tool-card__desc">Generate realistic mock data for API testing</p>
-                                <span class="chip tool-card__chip" data-category="api">API</span>
-                            </div>
-                        </a>
-                        <a href="tools/ascii-art-generator.html" class="tool-card" data-category="visual">
-                            <div class="tool-card__icon"><i class="fas fa-font" aria-hidden="true"></i></div>
-                            <div class="tool-card__body">
-                                <h3 class="tool-card__title">ASCII Art Generator</h3>
-                                <p class="tool-card__desc">Generate ASCII art from text with multiple fonts and styles</p>
-                                <span class="chip tool-card__chip" data-category="visual">Visual</span>
-                            </div>
-                        </a>
-                        <a href="tools/ascii-hex-converter.html" class="tool-card" data-category="encoding">
-                            <div class="tool-card__icon"><i class="fas fa-exchange-alt" aria-hidden="true"></i></div>
-                            <div class="tool-card__body">
-                                <h3 class="tool-card__title">ASCII ⇄ HEX Converter</h3>
-                                <p class="tool-card__desc">Convert between ASCII text and hexadecimal representation</p>
-                                <span class="chip tool-card__chip" data-category="encoding">Encoding</span>
-                            </div>
-                        </a>
-                        <a href="tools/backslash-escape-unescape.html" class="tool-card" data-category="text">
-                            <div class="tool-card__icon"><i class="fas fa-backspace" aria-hidden="true"></i></div>
-                            <div class="tool-card__body">
-                                <h3 class="tool-card__title">Backslash Escape/Unescape</h3>
-                                <p class="tool-card__desc">Escape and unescape backslashes in text</p>
-                                <span class="chip tool-card__chip" data-category="text">Text</span>
-                            </div>
-                        </a>
-                        <a href="tools/base64-encoder-decoder.html" class="tool-card" data-category="encoding">
-                            <div class="tool-card__icon"><i class="fas fa-exchange-alt" aria-hidden="true"></i></div>
-                            <div class="tool-card__body">
-                                <h3 class="tool-card__title">Base64 Encoder/Decoder</h3>
-                                <p class="tool-card__desc">Encode and decode text or files using Base64 encoding</p>
-                                <span class="chip tool-card__chip" data-category="encoding">Encoding</span>
-                            </div>
-                        </a>
-                        <a href="tools/color-converter.html" class="tool-card" data-category="visual">
-                            <div class="tool-card__icon"><i class="fas fa-palette" aria-hidden="true"></i></div>
-                            <div class="tool-card__body">
-                                <h3 class="tool-card__title">Color Converter</h3>
-                                <p class="tool-card__desc">Convert between HEX, RGB, and HSL color formats</p>
-                                <span class="chip tool-card__chip" data-category="visual">Visual</span>
-                            </div>
-                        </a>
-                        <a href="tools/crontab-generator.html" class="tool-card" data-category="time">
-                            <div class="tool-card__icon"><i class="fas fa-clock" aria-hidden="true"></i></div>
-                            <div class="tool-card__body">
-                                <h3 class="tool-card__title">Crontab Generator</h3>
-                                <p class="tool-card__desc">Create crontab expressions visually with human-readable descriptions</p>
-                                <span class="chip tool-card__chip" data-category="time">Time</span>
-                            </div>
-                        </a>
-                        <a href="tools/csv-json-converter.html" class="tool-card" data-category="data format">
-                            <div class="tool-card__icon"><i class="fas fa-file-code" aria-hidden="true"></i></div>
-                            <div class="tool-card__body">
-                                <h3 class="tool-card__title">CSV ⇄ JSON Converter</h3>
-                                <p class="tool-card__desc">Convert between CSV and JSON data formats</p>
-                                <span class="chip tool-card__chip" data-category="data format">Data</span>
-                            </div>
-                        </a>
-                        <a href="tools/csv-visualizer.html" class="tool-card" data-category="data format">
-                            <div class="tool-card__icon"><i class="fas fa-table" aria-hidden="true"></i></div>
-                            <div class="tool-card__body">
-                                <h3 class="tool-card__title">CSV Visualizer</h3>
-                                <p class="tool-card__desc">Visualize CSV data as HTML tables with export options</p>
-                                <span class="chip tool-card__chip" data-category="data format">Data</span>
-                            </div>
-                        </a>
-                        <a href="tools/curl-constructor.html" class="tool-card" data-category="web">
-                            <div class="tool-card__icon"><i class="fas fa-terminal" aria-hidden="true"></i></div>
-                            <div class="tool-card__body">
-                                <h3 class="tool-card__title">CURL Constructor</h3>
-                                <p class="tool-card__desc">Build CURL commands for terminal execution with customizable options</p>
-                                <span class="chip tool-card__chip" data-category="web">Web</span>
-                            </div>
-                        </a>
-                        <a href="tools/hash-generator.html" class="tool-card" data-category="crypto">
-                            <div class="tool-card__icon"><i class="fas fa-hashtag" aria-hidden="true"></i></div>
-                            <div class="tool-card__body">
-                                <h3 class="tool-card__title">Hash Generator</h3>
-                                <p class="tool-card__desc">Generate MD5, SHA-1, SHA-256, and SHA-512 hashes</p>
-                                <span class="chip tool-card__chip" data-category="crypto">Crypto</span>
-                            </div>
-                        </a>
-                        <a href="tools/json-formatter.html" class="tool-card" data-category="data format">
-                            <div class="tool-card__icon"><i class="fas fa-code" aria-hidden="true"></i></div>
-                            <div class="tool-card__body">
-                                <h3 class="tool-card__title">JSON Beautifier/Minifier</h3>
-                                <p class="tool-card__desc">Format and compress JSON with syntax highlighting</p>
-                                <span class="chip tool-card__chip" data-category="data format">Data</span>
-                            </div>
-                        </a>
-                        <a href="tools/json-to-protobuf.html" class="tool-card" data-category="data format">
-                            <div class="tool-card__icon"><i class="fas fa-cube" aria-hidden="true"></i></div>
-                            <div class="tool-card__body">
-                                <h3 class="tool-card__title">JSON to Protobuf</h3>
-                                <p class="tool-card__desc">Generate Protocol Buffer definitions from JSON examples</p>
-                                <span class="chip tool-card__chip" data-category="data format">Data</span>
-                            </div>
-                        </a>
-                        <a href="tools/json-yaml-explorer.html" class="tool-card" data-category="data format">
-                            <div class="tool-card__icon"><i class="fas fa-project-diagram" aria-hidden="true"></i></div>
-                            <div class="tool-card__body">
-                                <h3 class="tool-card__title">JSON/YAML Explorer</h3>
-                                <p class="tool-card__desc">Visualize and explore JSON and YAML data with interactive tree view</p>
-                                <span class="chip tool-card__chip" data-category="data format">Data</span>
-                            </div>
-                        </a>
-                        <a href="tools/json-yaml-converter.html" class="tool-card" data-category="data format">
-                            <div class="tool-card__icon"><i class="fas fa-sync-alt" aria-hidden="true"></i></div>
-                            <div class="tool-card__body">
-                                <h3 class="tool-card__title">JSON ⇄ YAML Converter</h3>
-                                <p class="tool-card__desc">Convert between JSON and YAML formats with validation</p>
-                                <span class="chip tool-card__chip" data-category="data format">Data</span>
-                            </div>
-                        </a>
-                        <a href="tools/jwt-decoder.html" class="tool-card" data-category="web">
-                            <div class="tool-card__icon"><i class="fas fa-key" aria-hidden="true"></i></div>
-                            <div class="tool-card__body">
-                                <h3 class="tool-card__title">JWT Decoder</h3>
-                                <p class="tool-card__desc">Decode and inspect JSON Web Tokens (JWT)</p>
-                                <span class="chip tool-card__chip" data-category="web">Web</span>
-                            </div>
-                        </a>
-                        <a href="tools/line-sort-dedupe.html" class="tool-card" data-category="text">
-                            <div class="tool-card__icon"><i class="fas fa-sort-alpha-down" aria-hidden="true"></i></div>
-                            <div class="tool-card__body">
-                                <h3 class="tool-card__title">Line Sort/Dedupe</h3>
-                                <p class="tool-card__desc">Sort lines alphabetically and remove duplicates</p>
-                                <span class="chip tool-card__chip" data-category="text">Text</span>
-                            </div>
-                        </a>
-                        <a href="tools/markdown-preview.html" class="tool-card" data-category="visual">
-                            <div class="tool-card__icon"><i class="fab fa-markdown" aria-hidden="true"></i></div>
-                            <div class="tool-card__body">
-                                <h3 class="tool-card__title">Markdown Preview</h3>
-                                <p class="tool-card__desc">Preview Markdown with live rendering</p>
-                                <span class="chip tool-card__chip" data-category="visual">Visual</span>
-                            </div>
-                        </a>
-                        <a href="tools/mermaid-diagram-editor.html" class="tool-card" data-category="visual">
-                            <div class="tool-card__icon"><i class="fas fa-project-diagram" aria-hidden="true"></i></div>
-                            <div class="tool-card__body">
-                                <h3 class="tool-card__title">Mermaid Diagram Editor</h3>
-                                <p class="tool-card__desc">Create diagrams with Mermaid syntax and live preview</p>
-                                <span class="chip tool-card__chip" data-category="visual">Visual</span>
-                            </div>
-                        </a>
-                        <a href="tools/ocr-tool.html" class="tool-card" data-category="visual">
-                            <div class="tool-card__icon"><i class="fas fa-eye" aria-hidden="true"></i></div>
-                            <div class="tool-card__body">
-                                <h3 class="tool-card__title">OCR Tool</h3>
-                                <p class="tool-card__desc">Extract text from images and PDFs using offline OCR</p>
-                                <span class="chip tool-card__chip" data-category="visual">Visual</span>
-                            </div>
-                        </a>
-                        <a href="tools/qr-code-tool.html" class="tool-card" data-category="visual">
-                            <div class="tool-card__icon"><i class="fas fa-qrcode" aria-hidden="true"></i></div>
-                            <div class="tool-card__body">
-                                <h3 class="tool-card__title">QR Code Reader/Generator</h3>
-                                <p class="tool-card__desc">Generate QR codes from text or URLs, and scan QR codes from images</p>
-                                <span class="chip tool-card__chip" data-category="visual">Visual</span>
-                            </div>
-                        </a>
-                        <a href="tools/password-generator.html" class="tool-card" data-category="crypto">
-                            <div class="tool-card__icon"><i class="fas fa-lock" aria-hidden="true"></i></div>
-                            <div class="tool-card__body">
-                                <h3 class="tool-card__title">Random Password Generator</h3>
-                                <p class="tool-card__desc">Generate secure random passwords with customizable options</p>
-                                <span class="chip tool-card__chip" data-category="crypto">Crypto</span>
-                            </div>
-                        </a>
-                        <a href="tools/string-generator.html" class="tool-card" data-category="text">
-                            <div class="tool-card__icon"><i class="fas fa-random" aria-hidden="true"></i></div>
-                            <div class="tool-card__body">
-                                <h3 class="tool-card__title">Random String Generator</h3>
-                                <p class="tool-card__desc">Generate random strings with patterns and custom options</p>
-                                <span class="chip tool-card__chip" data-category="text">Text</span>
-                            </div>
-                        </a>
-                        <a href="tools/secret-share.html" class="tool-card" data-category="crypto">
-                            <div class="tool-card__icon"><i class="fas fa-user-secret" aria-hidden="true"></i></div>
-                            <div class="tool-card__body">
-                                <h3 class="tool-card__title">Secret Share</h3>
-                                <p class="tool-card__desc">Securely share encrypted messages with password protection</p>
-                                <span class="chip tool-card__chip" data-category="crypto">Crypto</span>
-                            </div>
-                        </a>
-                        <a href="tools/regex-tester.html" class="tool-card" data-category="api">
-                            <div class="tool-card__icon"><i class="fas fa-search" aria-hidden="true"></i></div>
-                            <div class="tool-card__body">
-                                <h3 class="tool-card__title">Regular Expression Tester</h3>
-                                <p class="tool-card__desc">Test and validate regular expressions with live results</p>
-                                <span class="chip tool-card__chip" data-category="api">API</span>
-                            </div>
-                        </a>
-                        <a href="tools/string-case-converter.html" class="tool-card" data-category="text">
-                            <div class="tool-card__icon"><i class="fas fa-font" aria-hidden="true"></i></div>
-                            <div class="tool-card__body">
-                                <h3 class="tool-card__title">String Case Converter</h3>
-                                <p class="tool-card__desc">Convert between camelCase, snake_case, kebab-case and more</p>
-                                <span class="chip tool-card__chip" data-category="text">Text</span>
-                            </div>
-                        </a>
-                        <a href="tools/text-diff.html" class="tool-card" data-category="text">
-                            <div class="tool-card__icon"><i class="fas fa-columns" aria-hidden="true"></i></div>
-                            <div class="tool-card__body">
-                                <h3 class="tool-card__title">Text Diff Utility</h3>
-                                <p class="tool-card__desc">Compare two text blocks and highlight differences</p>
-                                <span class="chip tool-card__chip" data-category="text">Text</span>
-                            </div>
-                        </a>
-                        <a href="tools/timestamp-converter.html" class="tool-card" data-category="time">
-                            <div class="tool-card__icon"><i class="fas fa-calendar-alt" aria-hidden="true"></i></div>
-                            <div class="tool-card__body">
-                                <h3 class="tool-card__title">Timestamp Converter</h3>
-                                <p class="tool-card__desc">Convert between various timestamp formats and human-readable dates</p>
-                                <span class="chip tool-card__chip" data-category="time">Time</span>
-                            </div>
-                        </a>
-                        <a href="tools/url-encoder-decoder.html" class="tool-card" data-category="encoding">
-                            <div class="tool-card__icon"><i class="fas fa-link" aria-hidden="true"></i></div>
-                            <div class="tool-card__body">
-                                <h3 class="tool-card__title">URL Encoder/Decoder</h3>
-                                <p class="tool-card__desc">Encode and decode URLs and URL components</p>
-                                <span class="chip tool-card__chip" data-category="encoding">Encoding</span>
-                            </div>
-                        </a>
-                        <a href="tools/url-parser.html" class="tool-card" data-category="web">
-                            <div class="tool-card__icon"><i class="fas fa-sitemap" aria-hidden="true"></i></div>
-                            <div class="tool-card__body">
-                                <h3 class="tool-card__title">URL Parser</h3>
-                                <p class="tool-card__desc">Parse and extract components from URLs</p>
-                                <span class="chip tool-card__chip" data-category="web">Web</span>
-                            </div>
-                        </a>
-                        <a href="tools/url-to-markdown.html" class="tool-card" data-category="web">
-                            <div class="tool-card__icon"><i class="fas fa-file-alt" aria-hidden="true"></i></div>
-                            <div class="tool-card__body">
-                                <h3 class="tool-card__title">URL to Markdown</h3>
-                                <p class="tool-card__desc">Scrape URL content and convert to Markdown format</p>
-                                <span class="chip tool-card__chip" data-category="web">Web</span>
-                            </div>
-                        </a>
-                        <a href="tools/uuid-generator.html" class="tool-card" data-category="crypto">
-                            <div class="tool-card__icon"><i class="fas fa-fingerprint" aria-hidden="true"></i></div>
-                            <div class="tool-card__body">
-                                <h3 class="tool-card__title">UUID Generator</h3>
-                                <p class="tool-card__desc">Generate random UUIDs in version 4 format</p>
-                                <span class="chip tool-card__chip" data-category="crypto">Crypto</span>
-                            </div>
-                        </a>
-                        <a href="tools/vim-editor.html" class="tool-card" data-category="text">
-                            <div class="tool-card__icon"><i class="fas fa-keyboard" aria-hidden="true"></i></div>
-                            <div class="tool-card__body">
-                                <h3 class="tool-card__title">Vim-Style Code Editor</h3>
-                                <p class="tool-card__desc">Browser-based text editor with Vim key bindings</p>
-                                <span class="chip tool-card__chip" data-category="text">Text</span>
-                            </div>
-                        </a>
-                        <a href="tools/ip-lookup.html" class="tool-card" data-category="network">
-                            <div class="tool-card__icon"><i class="fas fa-globe" aria-hidden="true"></i></div>
-                            <div class="tool-card__body">
-                                <h3 class="tool-card__title">IP Address Lookup</h3>
-                                <p class="tool-card__desc">Get detailed information about any IP address including geolocation, ISP, and network details</p>
-                                <span class="chip tool-card__chip" data-category="network">Network</span>
-                            </div>
-                        </a>
-                        <a href="tools/ssl-checker.html" class="tool-card" data-category="network">
-                            <div class="tool-card__icon"><i class="fas fa-shield-alt" aria-hidden="true"></i></div>
-                            <div class="tool-card__body">
-                                <h3 class="tool-card__title">SSL/TLS Certificate Checker</h3>
-                                <p class="tool-card__desc">Analyze SSL/TLS certificates for any domain and check their security status</p>
-                                <span class="chip tool-card__chip" data-category="network">Network</span>
-                            </div>
-                        </a>
-                        <a href="tools/subnet-calculator.html" class="tool-card" data-category="network">
-                            <div class="tool-card__icon"><i class="fas fa-network-wired" aria-hidden="true"></i></div>
-                            <div class="tool-card__body">
-                                <h3 class="tool-card__title">Subnet Calculator</h3>
-                                <p class="tool-card__desc">Calculate subnet information, IP ranges, and network details from CIDR notation</p>
-                                <span class="chip tool-card__chip" data-category="network">Network</span>
-                            </div>
-                        </a>
-                    </div>
-
-                    <div id="no-results-message" class="no-results-message hidden">
-                        <div class="empty-state__icon"><i class="fas fa-search" aria-hidden="true"></i></div>
-                        <div class="empty-state__title">No tools match your search</div>
-                        <div>Try a different keyword or pick a different category.</div>
-                    </div>
-                </div>
-            </main>
-
-            <footer class="app-footer">
-                <p>&copy; <span id="current-year">2025</span> Devtools — open-source on
-                    <a href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener">GitHub</a> ·
-                    <a href="https://github.com/irfansofyana/Devtools/issues" target="_blank" rel="noopener">Report issues</a>
-                </p>
-            </footer>
+    <header class="top-bar">
+        <a href="index.html" class="brand">devtools</a>
+        <div class="top-bar__search">
+            <i class="fas fa-search top-bar__search-icon" aria-hidden="true"></i>
+            <input type="search" id="tool-search" class="top-bar__search-input" placeholder="search" aria-label="Search tools" autocomplete="off" spellcheck="false">
+            <button type="button" id="search-clear" class="top-bar__search-clear hidden" aria-label="Clear search">
+                <i class="fas fa-times" aria-hidden="true"></i>
+            </button>
         </div>
-    </div>
+        <div class="top-bar__actions">
+            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+                <i class="fab fa-github" aria-hidden="true"></i>
+            </a>
+            <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
+                <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg>
+                <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+            </button>
+        </div>
+    </header>
+
+    <main class="content" id="tools">
+        <div class="content__inner">
+            <p class="intro">
+                <span class="intro__prompt">$</span><span class="intro__count" id="tool-count">36</span> developer tools — offline, single-file, no tracking.
+            </p>
+
+            <section class="section" data-category="text">
+                <header class="section__header">
+                    <span class="section__index">01</span>
+                    <h2 class="section__title">Text</h2>
+                    <span class="section__count">6</span>
+                </header>
+                <div class="tool-grid">
+                    <a href="tools/string-case-converter.html" class="tool-card">
+                        <span class="tool-card__icon"><i class="fas fa-font" aria-hidden="true"></i></span>
+                        <div class="tool-card__body">
+                            <h3 class="tool-card__title">String Case Converter</h3>
+                            <p class="tool-card__desc">Convert between camelCase, snake_case, kebab-case and more</p>
+                        </div>
+                    </a>
+                    <a href="tools/line-sort-dedupe.html" class="tool-card">
+                        <span class="tool-card__icon"><i class="fas fa-sort-alpha-down" aria-hidden="true"></i></span>
+                        <div class="tool-card__body">
+                            <h3 class="tool-card__title">Line Sort &amp; Dedupe</h3>
+                            <p class="tool-card__desc">Sort lines alphabetically and remove duplicates</p>
+                        </div>
+                    </a>
+                    <a href="tools/backslash-escape-unescape.html" class="tool-card">
+                        <span class="tool-card__icon"><i class="fas fa-backspace" aria-hidden="true"></i></span>
+                        <div class="tool-card__body">
+                            <h3 class="tool-card__title">Backslash Escape</h3>
+                            <p class="tool-card__desc">Escape and unescape backslashes in text</p>
+                        </div>
+                    </a>
+                    <a href="tools/string-generator.html" class="tool-card">
+                        <span class="tool-card__icon"><i class="fas fa-random" aria-hidden="true"></i></span>
+                        <div class="tool-card__body">
+                            <h3 class="tool-card__title">Random String Generator</h3>
+                            <p class="tool-card__desc">Generate random strings with patterns and custom options</p>
+                        </div>
+                    </a>
+                    <a href="tools/text-diff.html" class="tool-card">
+                        <span class="tool-card__icon"><i class="fas fa-columns" aria-hidden="true"></i></span>
+                        <div class="tool-card__body">
+                            <h3 class="tool-card__title">Text Diff</h3>
+                            <p class="tool-card__desc">Compare two text blocks and highlight differences</p>
+                        </div>
+                    </a>
+                    <a href="tools/vim-editor.html" class="tool-card">
+                        <span class="tool-card__icon"><i class="fas fa-keyboard" aria-hidden="true"></i></span>
+                        <div class="tool-card__body">
+                            <h3 class="tool-card__title">Vim-Style Editor</h3>
+                            <p class="tool-card__desc">Browser-based text editor with Vim key bindings</p>
+                        </div>
+                    </a>
+                </div>
+            </section>
+
+            <section class="section" data-category="encoding">
+                <header class="section__header">
+                    <span class="section__index">02</span>
+                    <h2 class="section__title">Encoding</h2>
+                    <span class="section__count">3</span>
+                </header>
+                <div class="tool-grid">
+                    <a href="tools/base64-encoder-decoder.html" class="tool-card">
+                        <span class="tool-card__icon"><i class="fas fa-exchange-alt" aria-hidden="true"></i></span>
+                        <div class="tool-card__body">
+                            <h3 class="tool-card__title">Base64 Encoder</h3>
+                            <p class="tool-card__desc">Encode and decode text or files using Base64</p>
+                        </div>
+                    </a>
+                    <a href="tools/url-encoder-decoder.html" class="tool-card">
+                        <span class="tool-card__icon"><i class="fas fa-link" aria-hidden="true"></i></span>
+                        <div class="tool-card__body">
+                            <h3 class="tool-card__title">URL Encoder</h3>
+                            <p class="tool-card__desc">Encode and decode URLs and URL components</p>
+                        </div>
+                    </a>
+                    <a href="tools/ascii-hex-converter.html" class="tool-card">
+                        <span class="tool-card__icon"><i class="fas fa-exchange-alt" aria-hidden="true"></i></span>
+                        <div class="tool-card__body">
+                            <h3 class="tool-card__title">ASCII / HEX</h3>
+                            <p class="tool-card__desc">Convert between ASCII text and hexadecimal</p>
+                        </div>
+                    </a>
+                </div>
+            </section>
+
+            <section class="section" data-category="data">
+                <header class="section__header">
+                    <span class="section__index">03</span>
+                    <h2 class="section__title">Data</h2>
+                    <span class="section__count">6</span>
+                </header>
+                <div class="tool-grid">
+                    <a href="tools/json-formatter.html" class="tool-card">
+                        <span class="tool-card__icon"><i class="fas fa-code" aria-hidden="true"></i></span>
+                        <div class="tool-card__body">
+                            <h3 class="tool-card__title">JSON Formatter</h3>
+                            <p class="tool-card__desc">Beautify and minify JSON with syntax highlighting</p>
+                        </div>
+                    </a>
+                    <a href="tools/json-yaml-converter.html" class="tool-card">
+                        <span class="tool-card__icon"><i class="fas fa-sync-alt" aria-hidden="true"></i></span>
+                        <div class="tool-card__body">
+                            <h3 class="tool-card__title">JSON ↔ YAML</h3>
+                            <p class="tool-card__desc">Convert between JSON and YAML with validation</p>
+                        </div>
+                    </a>
+                    <a href="tools/csv-json-converter.html" class="tool-card">
+                        <span class="tool-card__icon"><i class="fas fa-file-code" aria-hidden="true"></i></span>
+                        <div class="tool-card__body">
+                            <h3 class="tool-card__title">CSV ↔ JSON</h3>
+                            <p class="tool-card__desc">Convert between CSV and JSON data formats</p>
+                        </div>
+                    </a>
+                    <a href="tools/csv-visualizer.html" class="tool-card">
+                        <span class="tool-card__icon"><i class="fas fa-table" aria-hidden="true"></i></span>
+                        <div class="tool-card__body">
+                            <h3 class="tool-card__title">CSV Visualizer</h3>
+                            <p class="tool-card__desc">Visualize CSV data as HTML tables with export</p>
+                        </div>
+                    </a>
+                    <a href="tools/json-to-protobuf.html" class="tool-card">
+                        <span class="tool-card__icon"><i class="fas fa-cube" aria-hidden="true"></i></span>
+                        <div class="tool-card__body">
+                            <h3 class="tool-card__title">JSON → Protobuf</h3>
+                            <p class="tool-card__desc">Generate Protocol Buffer definitions from JSON</p>
+                        </div>
+                    </a>
+                    <a href="tools/json-yaml-explorer.html" class="tool-card">
+                        <span class="tool-card__icon"><i class="fas fa-project-diagram" aria-hidden="true"></i></span>
+                        <div class="tool-card__body">
+                            <h3 class="tool-card__title">JSON/YAML Explorer</h3>
+                            <p class="tool-card__desc">Interactive tree view for JSON and YAML</p>
+                        </div>
+                    </a>
+                </div>
+            </section>
+
+            <section class="section" data-category="web">
+                <header class="section__header">
+                    <span class="section__index">04</span>
+                    <h2 class="section__title">Web</h2>
+                    <span class="section__count">4</span>
+                </header>
+                <div class="tool-grid">
+                    <a href="tools/url-parser.html" class="tool-card">
+                        <span class="tool-card__icon"><i class="fas fa-sitemap" aria-hidden="true"></i></span>
+                        <div class="tool-card__body">
+                            <h3 class="tool-card__title">URL Parser</h3>
+                            <p class="tool-card__desc">Parse and extract components from URLs</p>
+                        </div>
+                    </a>
+                    <a href="tools/curl-constructor.html" class="tool-card">
+                        <span class="tool-card__icon"><i class="fas fa-terminal" aria-hidden="true"></i></span>
+                        <div class="tool-card__body">
+                            <h3 class="tool-card__title">cURL Constructor</h3>
+                            <p class="tool-card__desc">Build cURL commands with customizable options</p>
+                        </div>
+                    </a>
+                    <a href="tools/jwt-decoder.html" class="tool-card">
+                        <span class="tool-card__icon"><i class="fas fa-key" aria-hidden="true"></i></span>
+                        <div class="tool-card__body">
+                            <h3 class="tool-card__title">JWT Decoder</h3>
+                            <p class="tool-card__desc">Decode and inspect JSON Web Tokens</p>
+                        </div>
+                    </a>
+                    <a href="tools/url-to-markdown.html" class="tool-card">
+                        <span class="tool-card__icon"><i class="fas fa-file-alt" aria-hidden="true"></i></span>
+                        <div class="tool-card__body">
+                            <h3 class="tool-card__title">URL → Markdown</h3>
+                            <p class="tool-card__desc">Scrape URL content and convert to Markdown</p>
+                        </div>
+                    </a>
+                </div>
+            </section>
+
+            <section class="section" data-category="crypto">
+                <header class="section__header">
+                    <span class="section__index">05</span>
+                    <h2 class="section__title">Crypto</h2>
+                    <span class="section__count">4</span>
+                </header>
+                <div class="tool-grid">
+                    <a href="tools/hash-generator.html" class="tool-card">
+                        <span class="tool-card__icon"><i class="fas fa-hashtag" aria-hidden="true"></i></span>
+                        <div class="tool-card__body">
+                            <h3 class="tool-card__title">Hash Generator</h3>
+                            <p class="tool-card__desc">MD5, SHA-1, SHA-256, SHA-512 hashes</p>
+                        </div>
+                    </a>
+                    <a href="tools/uuid-generator.html" class="tool-card">
+                        <span class="tool-card__icon"><i class="fas fa-fingerprint" aria-hidden="true"></i></span>
+                        <div class="tool-card__body">
+                            <h3 class="tool-card__title">UUID Generator</h3>
+                            <p class="tool-card__desc">Generate random UUIDs in version 4 format</p>
+                        </div>
+                    </a>
+                    <a href="tools/password-generator.html" class="tool-card">
+                        <span class="tool-card__icon"><i class="fas fa-lock" aria-hidden="true"></i></span>
+                        <div class="tool-card__body">
+                            <h3 class="tool-card__title">Password Generator</h3>
+                            <p class="tool-card__desc">Generate secure random passwords</p>
+                        </div>
+                    </a>
+                    <a href="tools/secret-share.html" class="tool-card">
+                        <span class="tool-card__icon"><i class="fas fa-user-secret" aria-hidden="true"></i></span>
+                        <div class="tool-card__body">
+                            <h3 class="tool-card__title">Secret Share</h3>
+                            <p class="tool-card__desc">Share encrypted messages with password protection</p>
+                        </div>
+                    </a>
+                </div>
+            </section>
+
+            <section class="section" data-category="time">
+                <header class="section__header">
+                    <span class="section__index">06</span>
+                    <h2 class="section__title">Time</h2>
+                    <span class="section__count">2</span>
+                </header>
+                <div class="tool-grid">
+                    <a href="tools/timestamp-converter.html" class="tool-card">
+                        <span class="tool-card__icon"><i class="fas fa-calendar-alt" aria-hidden="true"></i></span>
+                        <div class="tool-card__body">
+                            <h3 class="tool-card__title">Timestamp Converter</h3>
+                            <p class="tool-card__desc">Convert between timestamp formats and dates</p>
+                        </div>
+                    </a>
+                    <a href="tools/crontab-generator.html" class="tool-card">
+                        <span class="tool-card__icon"><i class="fas fa-clock" aria-hidden="true"></i></span>
+                        <div class="tool-card__body">
+                            <h3 class="tool-card__title">Crontab Generator</h3>
+                            <p class="tool-card__desc">Build crontab expressions with human-readable preview</p>
+                        </div>
+                    </a>
+                </div>
+            </section>
+
+            <section class="section" data-category="visual">
+                <header class="section__header">
+                    <span class="section__index">07</span>
+                    <h2 class="section__title">Visual</h2>
+                    <span class="section__count">6</span>
+                </header>
+                <div class="tool-grid">
+                    <a href="tools/color-converter.html" class="tool-card">
+                        <span class="tool-card__icon"><i class="fas fa-palette" aria-hidden="true"></i></span>
+                        <div class="tool-card__body">
+                            <h3 class="tool-card__title">Color Converter</h3>
+                            <p class="tool-card__desc">Convert between HEX, RGB, and HSL formats</p>
+                        </div>
+                    </a>
+                    <a href="tools/qr-code-tool.html" class="tool-card">
+                        <span class="tool-card__icon"><i class="fas fa-qrcode" aria-hidden="true"></i></span>
+                        <div class="tool-card__body">
+                            <h3 class="tool-card__title">QR Code Tool</h3>
+                            <p class="tool-card__desc">Generate and read QR codes from text or images</p>
+                        </div>
+                    </a>
+                    <a href="tools/markdown-preview.html" class="tool-card">
+                        <span class="tool-card__icon"><i class="fab fa-markdown" aria-hidden="true"></i></span>
+                        <div class="tool-card__body">
+                            <h3 class="tool-card__title">Markdown Preview</h3>
+                            <p class="tool-card__desc">Preview Markdown with live rendering</p>
+                        </div>
+                    </a>
+                    <a href="tools/mermaid-diagram-editor.html" class="tool-card">
+                        <span class="tool-card__icon"><i class="fas fa-project-diagram" aria-hidden="true"></i></span>
+                        <div class="tool-card__body">
+                            <h3 class="tool-card__title">Mermaid Editor</h3>
+                            <p class="tool-card__desc">Create diagrams with Mermaid syntax and live preview</p>
+                        </div>
+                    </a>
+                    <a href="tools/ocr-tool.html" class="tool-card">
+                        <span class="tool-card__icon"><i class="fas fa-eye" aria-hidden="true"></i></span>
+                        <div class="tool-card__body">
+                            <h3 class="tool-card__title">OCR Tool</h3>
+                            <p class="tool-card__desc">Extract text from images and PDFs offline</p>
+                        </div>
+                    </a>
+                    <a href="tools/ascii-art-generator.html" class="tool-card">
+                        <span class="tool-card__icon"><i class="fas fa-font" aria-hidden="true"></i></span>
+                        <div class="tool-card__body">
+                            <h3 class="tool-card__title">ASCII Art</h3>
+                            <p class="tool-card__desc">Generate ASCII art from text with multiple fonts</p>
+                        </div>
+                    </a>
+                </div>
+            </section>
+
+            <section class="section" data-category="api">
+                <header class="section__header">
+                    <span class="section__index">08</span>
+                    <h2 class="section__title">API</h2>
+                    <span class="section__count">2</span>
+                </header>
+                <div class="tool-grid">
+                    <a href="tools/api-mock-generator.html" class="tool-card">
+                        <span class="tool-card__icon"><i class="fas fa-vial" aria-hidden="true"></i></span>
+                        <div class="tool-card__body">
+                            <h3 class="tool-card__title">API Mock Data</h3>
+                            <p class="tool-card__desc">Generate realistic mock data for API testing</p>
+                        </div>
+                    </a>
+                    <a href="tools/regex-tester.html" class="tool-card">
+                        <span class="tool-card__icon"><i class="fas fa-search" aria-hidden="true"></i></span>
+                        <div class="tool-card__body">
+                            <h3 class="tool-card__title">Regex Tester</h3>
+                            <p class="tool-card__desc">Test and validate regular expressions live</p>
+                        </div>
+                    </a>
+                </div>
+            </section>
+
+            <section class="section" data-category="network">
+                <header class="section__header">
+                    <span class="section__index">09</span>
+                    <h2 class="section__title">Network</h2>
+                    <span class="section__count">3</span>
+                </header>
+                <div class="tool-grid">
+                    <a href="tools/ip-lookup.html" class="tool-card">
+                        <span class="tool-card__icon"><i class="fas fa-globe" aria-hidden="true"></i></span>
+                        <div class="tool-card__body">
+                            <h3 class="tool-card__title">IP Lookup</h3>
+                            <p class="tool-card__desc">Geolocation, ISP, and network details for any IP</p>
+                        </div>
+                    </a>
+                    <a href="tools/ssl-checker.html" class="tool-card">
+                        <span class="tool-card__icon"><i class="fas fa-shield-alt" aria-hidden="true"></i></span>
+                        <div class="tool-card__body">
+                            <h3 class="tool-card__title">SSL/TLS Checker</h3>
+                            <p class="tool-card__desc">Analyze certificates and security status for any domain</p>
+                        </div>
+                    </a>
+                    <a href="tools/subnet-calculator.html" class="tool-card">
+                        <span class="tool-card__icon"><i class="fas fa-network-wired" aria-hidden="true"></i></span>
+                        <div class="tool-card__body">
+                            <h3 class="tool-card__title">Subnet Calculator</h3>
+                            <p class="tool-card__desc">Compute subnet ranges from CIDR notation</p>
+                        </div>
+                    </a>
+                </div>
+            </section>
+
+            <div id="no-results-message" class="no-results-message hidden">
+                no tools match your search
+            </div>
+        </div>
+    </main>
+
+    <footer class="app-footer">
+        <div class="app-footer__inner">
+            <p>&copy; <span id="current-year">2025</span> devtools · <a href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener">source</a> · <a href="https://github.com/irfansofyana/Devtools/issues" target="_blank" rel="noopener">issues</a></p>
+            <p>built by <a href="https://github.com/irfansofyana" target="_blank" rel="noopener">irfansofyana</a></p>
+        </div>
+    </footer>
 
     <script src="js/theme.js"></script>
     <script src="js/main.js"></script>

--- a/js/main.js
+++ b/js/main.js
@@ -26,14 +26,19 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 /**
- * On tool pages, mirror the page <h1> into the top-bar title slot
- * so the sticky header always shows the current tool name.
+ * On tool pages, slugify the page <h1> into the top-bar breadcrumb slot.
+ * (e.g. "JSON Beautifier/Minifier" -> "json-beautifier-minifier")
  */
 function populateToolPageTitle() {
-    const slot = document.querySelector('.tool-page-shell .top-bar__title');
+    const slot = document.getElementById('tool-crumb');
     if (!slot || slot.textContent.trim()) return;
     const h1 = document.querySelector('.tool-header h1, main h1');
-    if (h1) slot.textContent = h1.textContent.trim();
+    if (!h1) return;
+    slot.textContent = h1.textContent
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-|-$/g, '');
 }
 
 /**

--- a/js/search.js
+++ b/js/search.js
@@ -1,184 +1,71 @@
 /**
- * Devtools — homepage search, category sidebar, keyboard shortcuts.
+ * Devtools — homepage search.
  *
- * Behaviour:
- * - Reads `data-category` from each `.tool-card` in the HTML (no DOM injection
- *   of category tags at runtime — the chips are already in the markup).
- * - Renders a category list with counts into the sidebar.
- * - Wires search input + category clicks to filter the grid.
- * - Persists the active category in localStorage.
- * - Ctrl/Cmd+K focuses the search input; Esc clears it.
- * - Hamburger toggles the sidebar on mobile.
+ * - Filters tool cards by query (matches title + description).
+ * - Hides entire sections that have no matching cards.
+ * - Ctrl/Cmd+K focuses search; Esc clears it.
  */
 
-const TOOL_CATEGORIES = [
-    { id: 'all',         label: 'All Tools',  icon: 'fa-th-large' },
-    { id: 'text',        label: 'Text',       icon: 'fa-align-left' },
-    { id: 'encoding',    label: 'Encoding',   icon: 'fa-exchange-alt' },
-    { id: 'data format', label: 'Data',       icon: 'fa-database' },
-    { id: 'web',         label: 'Web',        icon: 'fa-globe' },
-    { id: 'crypto',      label: 'Crypto',     icon: 'fa-shield-alt' },
-    { id: 'time',        label: 'Time',       icon: 'fa-clock' },
-    { id: 'visual',      label: 'Visual',     icon: 'fa-image' },
-    { id: 'api',         label: 'API',        icon: 'fa-plug' },
-    { id: 'network',     label: 'Network',    icon: 'fa-network-wired' },
-];
-
-const STORAGE_KEY = 'devtools-active-category';
-
 document.addEventListener('DOMContentLoaded', () => {
-    const grid = document.getElementById('tools-grid');
-    if (!grid) return;
-
-    const cards = Array.from(grid.querySelectorAll('.tool-card'));
-    const searchInput = document.getElementById('tool-search');
+    const input = document.getElementById('tool-search');
     const clearBtn = document.getElementById('search-clear');
-    const navContainer = document.getElementById('category-nav');
-    const topBarTitle = document.querySelector('.top-bar__title');
-    const toolCountEl = document.getElementById('tool-count');
+    const sections = Array.from(document.querySelectorAll('.section'));
+    const noResults = document.getElementById('no-results-message');
+    if (!input || sections.length === 0) return;
 
-    // Update total tool count in hero strip
-    if (toolCountEl) {
-        toolCountEl.textContent = `${cards.length} tools`;
-    }
+    const cards = sections.flatMap(s => Array.from(s.querySelectorAll('.tool-card')));
 
-    let activeCategory = loadActiveCategory();
-    let activeQuery = '';
+    function applyFilter(q) {
+        const query = q.trim().toLowerCase();
+        let totalVisible = 0;
 
-    renderSidebar();
-    applyFilter();
-    setupSearch();
-    setupKeyboardShortcuts();
-    setupMobileSidebar();
+        sections.forEach(section => {
+            const sectionCards = Array.from(section.querySelectorAll('.tool-card'));
+            let visibleInSection = 0;
 
-    function renderSidebar() {
-        if (!navContainer) return;
-        const counts = countByCategory(cards);
-        navContainer.innerHTML = '';
-        TOOL_CATEGORIES.forEach(cat => {
-            const count = cat.id === 'all' ? cards.length : (counts[cat.id] || 0);
-            if (cat.id !== 'all' && count === 0) return;
-            const link = document.createElement('button');
-            link.type = 'button';
-            link.className = 'sidebar__link';
-            link.dataset.category = cat.id;
-            link.setAttribute('aria-pressed', String(cat.id === activeCategory));
-            if (cat.id === activeCategory) link.classList.add('is-active');
-            link.innerHTML = `
-                <span class="sidebar__link-label">
-                    <span class="sidebar__link-icon"><i class="fas ${cat.icon}" aria-hidden="true"></i></span>
-                    ${cat.label}
-                </span>
-                <span class="sidebar__count">${count}</span>
-            `;
-            link.addEventListener('click', () => {
-                setActiveCategory(cat.id);
-                closeMobileSidebar();
+            sectionCards.forEach(card => {
+                const title = card.querySelector('.tool-card__title')?.textContent.toLowerCase() || '';
+                const desc = card.querySelector('.tool-card__desc')?.textContent.toLowerCase() || '';
+                const match = query === '' || title.includes(query) || desc.includes(query);
+                card.hidden = !match;
+                if (match) visibleInSection++;
             });
-            navContainer.appendChild(link);
+
+            section.hidden = visibleInSection === 0;
+            totalVisible += visibleInSection;
         });
+
+        if (noResults) noResults.classList.toggle('hidden', totalVisible !== 0);
     }
 
-    function countByCategory(allCards) {
-        return allCards.reduce((acc, card) => {
-            const c = card.getAttribute('data-category') || 'other';
-            acc[c] = (acc[c] || 0) + 1;
-            return acc;
-        }, {});
-    }
+    input.addEventListener('input', () => {
+        const q = input.value;
+        clearBtn?.classList.toggle('hidden', q.length === 0);
+        applyFilter(q);
+    });
 
-    function setActiveCategory(id) {
-        activeCategory = id;
-        try { localStorage.setItem(STORAGE_KEY, id); } catch (_) { /* ignore */ }
-        navContainer.querySelectorAll('.sidebar__link').forEach(el => {
-            const isActive = el.dataset.category === id;
-            el.classList.toggle('is-active', isActive);
-            el.setAttribute('aria-pressed', String(isActive));
-        });
-        if (topBarTitle) {
-            const cat = TOOL_CATEGORIES.find(c => c.id === id);
-            topBarTitle.textContent = cat ? cat.label : 'All Tools';
+    clearBtn?.addEventListener('click', () => {
+        input.value = '';
+        clearBtn.classList.add('hidden');
+        applyFilter('');
+        input.focus();
+    });
+
+    document.addEventListener('keydown', (e) => {
+        const isMac = navigator.platform.toUpperCase().includes('MAC');
+        if ((isMac ? e.metaKey : e.ctrlKey) && e.key.toLowerCase() === 'k') {
+            e.preventDefault();
+            input.focus();
+            input.select();
         }
-        applyFilter();
-    }
-
-    function loadActiveCategory() {
-        try {
-            const stored = localStorage.getItem(STORAGE_KEY);
-            if (stored && TOOL_CATEGORIES.some(c => c.id === stored)) return stored;
-        } catch (_) { /* ignore */ }
-        return 'all';
-    }
-
-    function setupSearch() {
-        if (!searchInput) return;
-        searchInput.addEventListener('input', () => {
-            activeQuery = searchInput.value.trim().toLowerCase();
-            if (clearBtn) clearBtn.classList.toggle('hidden', activeQuery.length === 0);
-            applyFilter();
-        });
-        if (clearBtn) {
-            clearBtn.addEventListener('click', () => {
-                searchInput.value = '';
-                activeQuery = '';
-                clearBtn.classList.add('hidden');
-                applyFilter();
-                searchInput.focus();
-            });
+        if (e.key === 'Escape' && document.activeElement === input) {
+            input.value = '';
+            clearBtn?.classList.add('hidden');
+            applyFilter('');
+            input.blur();
         }
-    }
+    });
 
-    function setupKeyboardShortcuts() {
-        document.addEventListener('keydown', (e) => {
-            const isMac = navigator.platform.toUpperCase().includes('MAC');
-            const cmdK = (isMac ? e.metaKey : e.ctrlKey) && e.key.toLowerCase() === 'k';
-            if (cmdK) {
-                e.preventDefault();
-                searchInput?.focus();
-                searchInput?.select();
-            }
-            if (e.key === 'Escape' && document.activeElement === searchInput) {
-                searchInput.value = '';
-                activeQuery = '';
-                clearBtn?.classList.add('hidden');
-                applyFilter();
-                searchInput.blur();
-            }
-        });
-    }
-
-    function setupMobileSidebar() {
-        const toggle = document.getElementById('sidebar-toggle');
-        const scrim = document.getElementById('sidebar-scrim');
-        if (!toggle) return;
-        toggle.addEventListener('click', () => {
-            const open = !document.body.classList.contains('sidebar-open');
-            document.body.classList.toggle('sidebar-open', open);
-            toggle.setAttribute('aria-expanded', String(open));
-        });
-        scrim?.addEventListener('click', closeMobileSidebar);
-    }
-
-    function closeMobileSidebar() {
-        if (!document.body.classList.contains('sidebar-open')) return;
-        document.body.classList.remove('sidebar-open');
-        document.getElementById('sidebar-toggle')?.setAttribute('aria-expanded', 'false');
-    }
-
-    function applyFilter() {
-        const noResults = document.getElementById('no-results-message');
-        let visible = 0;
-        cards.forEach(card => {
-            const cat = card.getAttribute('data-category') || 'other';
-            const title = card.querySelector('.tool-card__title, h3')?.textContent.toLowerCase() || '';
-            const desc = card.querySelector('.tool-card__desc, p')?.textContent.toLowerCase() || '';
-            const matchesCat = activeCategory === 'all' || cat === activeCategory;
-            const matchesQuery = activeQuery === '' ||
-                title.includes(activeQuery) || desc.includes(activeQuery);
-            const show = matchesCat && matchesQuery;
-            card.style.display = show ? '' : 'none';
-            if (show) visible++;
-        });
-        if (noResults) noResults.classList.toggle('hidden', visible !== 0);
-    }
+    const countEl = document.getElementById('tool-count');
+    if (countEl) countEl.textContent = String(cards.length);
 });

--- a/tools/api-mock-generator.html
+++ b/tools/api-mock-generator.html
@@ -11,7 +11,7 @@
     <link rel="stylesheet" href="../css/components.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
     <style>
         .template-container {
@@ -318,14 +318,12 @@
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
-            <i class="fas fa-arrow-left" aria-hidden="true"></i>
-            <span>All tools</span>
-        </a>
-        <div class="top-bar__title"></div>
+        <a href="../index.html" class="brand">devtools</a>
+        <span class="top-bar__crumb-sep">/</span>
+        <span class="top-bar__crumb-current" id="tool-crumb"></span>
         <div class="toolbar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">

--- a/tools/ascii-art-generator.html
+++ b/tools/ascii-art-generator.html
@@ -11,20 +11,18 @@
     <link rel="stylesheet" href="../css/components.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
-            <i class="fas fa-arrow-left" aria-hidden="true"></i>
-            <span>All tools</span>
-        </a>
-        <div class="top-bar__title"></div>
+        <a href="../index.html" class="brand">devtools</a>
+        <span class="top-bar__crumb-sep">/</span>
+        <span class="top-bar__crumb-current" id="tool-crumb"></span>
         <div class="toolbar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">

--- a/tools/ascii-hex-converter.html
+++ b/tools/ascii-hex-converter.html
@@ -11,7 +11,7 @@
     <link rel="stylesheet" href="../css/components.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap">
     <link rel="icon" href="../assets/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="../assets/favicon-32x32.png" type="image/png" sizes="32x32">
     <link rel="apple-touch-icon" href="../assets/apple-touch-icon.png">
@@ -19,14 +19,12 @@
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
-            <i class="fas fa-arrow-left" aria-hidden="true"></i>
-            <span>All tools</span>
-        </a>
-        <div class="top-bar__title"></div>
+        <a href="../index.html" class="brand">devtools</a>
+        <span class="top-bar__crumb-sep">/</span>
+        <span class="top-bar__crumb-current" id="tool-crumb"></span>
         <div class="toolbar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">

--- a/tools/backslash-escape-unescape.html
+++ b/tools/backslash-escape-unescape.html
@@ -11,20 +11,18 @@
     <link rel="stylesheet" href="../css/components.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
-            <i class="fas fa-arrow-left" aria-hidden="true"></i>
-            <span>All tools</span>
-        </a>
-        <div class="top-bar__title"></div>
+        <a href="../index.html" class="brand">devtools</a>
+        <span class="top-bar__crumb-sep">/</span>
+        <span class="top-bar__crumb-current" id="tool-crumb"></span>
         <div class="toolbar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">

--- a/tools/base64-encoder-decoder.html
+++ b/tools/base64-encoder-decoder.html
@@ -11,20 +11,18 @@
     <link rel="stylesheet" href="../css/components.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
-            <i class="fas fa-arrow-left" aria-hidden="true"></i>
-            <span>All tools</span>
-        </a>
-        <div class="top-bar__title"></div>
+        <a href="../index.html" class="brand">devtools</a>
+        <span class="top-bar__crumb-sep">/</span>
+        <span class="top-bar__crumb-current" id="tool-crumb"></span>
         <div class="toolbar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">

--- a/tools/color-converter.html
+++ b/tools/color-converter.html
@@ -11,20 +11,18 @@
     <link rel="stylesheet" href="../css/components.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
-            <i class="fas fa-arrow-left" aria-hidden="true"></i>
-            <span>All tools</span>
-        </a>
-        <div class="top-bar__title"></div>
+        <a href="../index.html" class="brand">devtools</a>
+        <span class="top-bar__crumb-sep">/</span>
+        <span class="top-bar__crumb-current" id="tool-crumb"></span>
         <div class="toolbar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">

--- a/tools/crontab-generator.html
+++ b/tools/crontab-generator.html
@@ -11,20 +11,18 @@
     <link rel="stylesheet" href="../css/components.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
-            <i class="fas fa-arrow-left" aria-hidden="true"></i>
-            <span>All tools</span>
-        </a>
-        <div class="top-bar__title"></div>
+        <a href="../index.html" class="brand">devtools</a>
+        <span class="top-bar__crumb-sep">/</span>
+        <span class="top-bar__crumb-current" id="tool-crumb"></span>
         <div class="toolbar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">

--- a/tools/csv-json-converter.html
+++ b/tools/csv-json-converter.html
@@ -11,20 +11,18 @@
     <link rel="stylesheet" href="../css/components.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
-            <i class="fas fa-arrow-left" aria-hidden="true"></i>
-            <span>All tools</span>
-        </a>
-        <div class="top-bar__title"></div>
+        <a href="../index.html" class="brand">devtools</a>
+        <span class="top-bar__crumb-sep">/</span>
+        <span class="top-bar__crumb-current" id="tool-crumb"></span>
         <div class="toolbar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">

--- a/tools/csv-visualizer.html
+++ b/tools/csv-visualizer.html
@@ -11,21 +11,19 @@
     <link rel="stylesheet" href="../css/components.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
     <script src="https://cdn.jsdelivr.net/npm/papaparse@5.4.1/papaparse.min.js"></script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
-            <i class="fas fa-arrow-left" aria-hidden="true"></i>
-            <span>All tools</span>
-        </a>
-        <div class="top-bar__title"></div>
+        <a href="../index.html" class="brand">devtools</a>
+        <span class="top-bar__crumb-sep">/</span>
+        <span class="top-bar__crumb-current" id="tool-crumb"></span>
         <div class="toolbar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">

--- a/tools/curl-constructor.html
+++ b/tools/curl-constructor.html
@@ -11,20 +11,18 @@
     <link rel="stylesheet" href="../css/components.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
-            <i class="fas fa-arrow-left" aria-hidden="true"></i>
-            <span>All tools</span>
-        </a>
-        <div class="top-bar__title"></div>
+        <a href="../index.html" class="brand">devtools</a>
+        <span class="top-bar__crumb-sep">/</span>
+        <span class="top-bar__crumb-current" id="tool-crumb"></span>
         <div class="toolbar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">

--- a/tools/hash-generator.html
+++ b/tools/hash-generator.html
@@ -11,20 +11,18 @@
     <link rel="stylesheet" href="../css/components.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
-            <i class="fas fa-arrow-left" aria-hidden="true"></i>
-            <span>All tools</span>
-        </a>
-        <div class="top-bar__title"></div>
+        <a href="../index.html" class="brand">devtools</a>
+        <span class="top-bar__crumb-sep">/</span>
+        <span class="top-bar__crumb-current" id="tool-crumb"></span>
         <div class="toolbar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">

--- a/tools/ip-lookup.html
+++ b/tools/ip-lookup.html
@@ -10,20 +10,18 @@
     <link rel="stylesheet" href="../css/components.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap">
     <link rel="icon" type="image/x-icon" href="../assets/favicon.ico">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
-            <i class="fas fa-arrow-left" aria-hidden="true"></i>
-            <span>All tools</span>
-        </a>
-        <div class="top-bar__title"></div>
+        <a href="../index.html" class="brand">devtools</a>
+        <span class="top-bar__crumb-sep">/</span>
+        <span class="top-bar__crumb-current" id="tool-crumb"></span>
         <div class="toolbar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">

--- a/tools/json-formatter.html
+++ b/tools/json-formatter.html
@@ -11,7 +11,7 @@
     <link rel="stylesheet" href="../css/components.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
     <!-- Prism.js for syntax highlighting -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.24.1/themes/prism.min.css">
@@ -20,14 +20,12 @@
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
-            <i class="fas fa-arrow-left" aria-hidden="true"></i>
-            <span>All tools</span>
-        </a>
-        <div class="top-bar__title"></div>
+        <a href="../index.html" class="brand">devtools</a>
+        <span class="top-bar__crumb-sep">/</span>
+        <span class="top-bar__crumb-current" id="tool-crumb"></span>
         <div class="toolbar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">

--- a/tools/json-to-protobuf.html
+++ b/tools/json-to-protobuf.html
@@ -11,20 +11,18 @@
     <link rel="stylesheet" href="../css/components.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
-            <i class="fas fa-arrow-left" aria-hidden="true"></i>
-            <span>All tools</span>
-        </a>
-        <div class="top-bar__title"></div>
+        <a href="../index.html" class="brand">devtools</a>
+        <span class="top-bar__crumb-sep">/</span>
+        <span class="top-bar__crumb-current" id="tool-crumb"></span>
         <div class="toolbar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">

--- a/tools/json-yaml-converter.html
+++ b/tools/json-yaml-converter.html
@@ -11,20 +11,18 @@
     <link rel="stylesheet" href="../css/components.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
-            <i class="fas fa-arrow-left" aria-hidden="true"></i>
-            <span>All tools</span>
-        </a>
-        <div class="top-bar__title"></div>
+        <a href="../index.html" class="brand">devtools</a>
+        <span class="top-bar__crumb-sep">/</span>
+        <span class="top-bar__crumb-current" id="tool-crumb"></span>
         <div class="toolbar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">

--- a/tools/json-yaml-explorer.html
+++ b/tools/json-yaml-explorer.html
@@ -11,7 +11,7 @@
     <link rel="stylesheet" href="../css/components.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
     <!-- Include jsoneditor for visualization -->
     <link href="https://cdnjs.cloudflare.com/ajax/libs/jsoneditor/9.10.0/jsoneditor.min.css" rel="stylesheet" type="text/css">
@@ -22,14 +22,12 @@
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
-            <i class="fas fa-arrow-left" aria-hidden="true"></i>
-            <span>All tools</span>
-        </a>
-        <div class="top-bar__title"></div>
+        <a href="../index.html" class="brand">devtools</a>
+        <span class="top-bar__crumb-sep">/</span>
+        <span class="top-bar__crumb-current" id="tool-crumb"></span>
         <div class="toolbar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">

--- a/tools/jwt-decoder.html
+++ b/tools/jwt-decoder.html
@@ -11,20 +11,18 @@
     <link rel="stylesheet" href="../css/components.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
-            <i class="fas fa-arrow-left" aria-hidden="true"></i>
-            <span>All tools</span>
-        </a>
-        <div class="top-bar__title"></div>
+        <a href="../index.html" class="brand">devtools</a>
+        <span class="top-bar__crumb-sep">/</span>
+        <span class="top-bar__crumb-current" id="tool-crumb"></span>
         <div class="toolbar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">

--- a/tools/line-sort-dedupe.html
+++ b/tools/line-sort-dedupe.html
@@ -11,20 +11,18 @@
     <link rel="stylesheet" href="../css/components.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
-            <i class="fas fa-arrow-left" aria-hidden="true"></i>
-            <span>All tools</span>
-        </a>
-        <div class="top-bar__title"></div>
+        <a href="../index.html" class="brand">devtools</a>
+        <span class="top-bar__crumb-sep">/</span>
+        <span class="top-bar__crumb-current" id="tool-crumb"></span>
         <div class="toolbar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">

--- a/tools/markdown-preview.html
+++ b/tools/markdown-preview.html
@@ -11,7 +11,7 @@
     <link rel="stylesheet" href="../css/components.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
     <style>
         .preview-container {
@@ -179,14 +179,12 @@
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
-            <i class="fas fa-arrow-left" aria-hidden="true"></i>
-            <span>All tools</span>
-        </a>
-        <div class="top-bar__title"></div>
+        <a href="../index.html" class="brand">devtools</a>
+        <span class="top-bar__crumb-sep">/</span>
+        <span class="top-bar__crumb-current" id="tool-crumb"></span>
         <div class="toolbar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">

--- a/tools/mermaid-diagram-editor.html
+++ b/tools/mermaid-diagram-editor.html
@@ -11,7 +11,7 @@
     <link rel="stylesheet" href="../css/components.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
     <!-- Mermaid.js for diagram rendering -->
     <script src="https://cdn.jsdelivr.net/npm/mermaid@10.6.1/dist/mermaid.min.js"></script>
@@ -131,14 +131,12 @@
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
-            <i class="fas fa-arrow-left" aria-hidden="true"></i>
-            <span>All tools</span>
-        </a>
-        <div class="top-bar__title"></div>
+        <a href="../index.html" class="brand">devtools</a>
+        <span class="top-bar__crumb-sep">/</span>
+        <span class="top-bar__crumb-current" id="tool-crumb"></span>
         <div class="toolbar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">

--- a/tools/ocr-tool.html
+++ b/tools/ocr-tool.html
@@ -11,7 +11,7 @@
     <link rel="stylesheet" href="../css/components.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
     <style>
         .drop-zone {
@@ -102,14 +102,12 @@
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
-            <i class="fas fa-arrow-left" aria-hidden="true"></i>
-            <span>All tools</span>
-        </a>
-        <div class="top-bar__title"></div>
+        <a href="../index.html" class="brand">devtools</a>
+        <span class="top-bar__crumb-sep">/</span>
+        <span class="top-bar__crumb-current" id="tool-crumb"></span>
         <div class="toolbar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">

--- a/tools/password-generator.html
+++ b/tools/password-generator.html
@@ -11,20 +11,18 @@
     <link rel="stylesheet" href="../css/components.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
-            <i class="fas fa-arrow-left" aria-hidden="true"></i>
-            <span>All tools</span>
-        </a>
-        <div class="top-bar__title"></div>
+        <a href="../index.html" class="brand">devtools</a>
+        <span class="top-bar__crumb-sep">/</span>
+        <span class="top-bar__crumb-current" id="tool-crumb"></span>
         <div class="toolbar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">

--- a/tools/qr-code-tool.html
+++ b/tools/qr-code-tool.html
@@ -11,7 +11,7 @@
     <link rel="stylesheet" href="../css/components.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap">
     <link rel="icon" href="../assets/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="../assets/favicon-32x32.png" type="image/png" sizes="32x32">
     <link rel="apple-touch-icon" href="../assets/apple-touch-icon.png">
@@ -21,14 +21,12 @@
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
-            <i class="fas fa-arrow-left" aria-hidden="true"></i>
-            <span>All tools</span>
-        </a>
-        <div class="top-bar__title"></div>
+        <a href="../index.html" class="brand">devtools</a>
+        <span class="top-bar__crumb-sep">/</span>
+        <span class="top-bar__crumb-current" id="tool-crumb"></span>
         <div class="toolbar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">

--- a/tools/regex-tester.html
+++ b/tools/regex-tester.html
@@ -11,20 +11,18 @@
     <link rel="stylesheet" href="../css/components.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
-            <i class="fas fa-arrow-left" aria-hidden="true"></i>
-            <span>All tools</span>
-        </a>
-        <div class="top-bar__title"></div>
+        <a href="../index.html" class="brand">devtools</a>
+        <span class="top-bar__crumb-sep">/</span>
+        <span class="top-bar__crumb-current" id="tool-crumb"></span>
         <div class="toolbar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">

--- a/tools/secret-share.html
+++ b/tools/secret-share.html
@@ -11,20 +11,18 @@
     <link rel="stylesheet" href="../css/components.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
-            <i class="fas fa-arrow-left" aria-hidden="true"></i>
-            <span>All tools</span>
-        </a>
-        <div class="top-bar__title"></div>
+        <a href="../index.html" class="brand">devtools</a>
+        <span class="top-bar__crumb-sep">/</span>
+        <span class="top-bar__crumb-current" id="tool-crumb"></span>
         <div class="toolbar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">

--- a/tools/ssl-checker.html
+++ b/tools/ssl-checker.html
@@ -10,20 +10,18 @@
     <link rel="stylesheet" href="../css/components.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap">
     <link rel="icon" type="image/x-icon" href="../assets/favicon.ico">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
-            <i class="fas fa-arrow-left" aria-hidden="true"></i>
-            <span>All tools</span>
-        </a>
-        <div class="top-bar__title"></div>
+        <a href="../index.html" class="brand">devtools</a>
+        <span class="top-bar__crumb-sep">/</span>
+        <span class="top-bar__crumb-current" id="tool-crumb"></span>
         <div class="toolbar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">

--- a/tools/string-case-converter.html
+++ b/tools/string-case-converter.html
@@ -11,20 +11,18 @@
     <link rel="stylesheet" href="../css/components.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
-            <i class="fas fa-arrow-left" aria-hidden="true"></i>
-            <span>All tools</span>
-        </a>
-        <div class="top-bar__title"></div>
+        <a href="../index.html" class="brand">devtools</a>
+        <span class="top-bar__crumb-sep">/</span>
+        <span class="top-bar__crumb-current" id="tool-crumb"></span>
         <div class="toolbar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">

--- a/tools/string-generator.html
+++ b/tools/string-generator.html
@@ -11,20 +11,18 @@
     <link rel="stylesheet" href="../css/components.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
-            <i class="fas fa-arrow-left" aria-hidden="true"></i>
-            <span>All tools</span>
-        </a>
-        <div class="top-bar__title"></div>
+        <a href="../index.html" class="brand">devtools</a>
+        <span class="top-bar__crumb-sep">/</span>
+        <span class="top-bar__crumb-current" id="tool-crumb"></span>
         <div class="toolbar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">

--- a/tools/subnet-calculator.html
+++ b/tools/subnet-calculator.html
@@ -10,20 +10,18 @@
     <link rel="stylesheet" href="../css/components.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap">
     <link rel="icon" type="image/x-icon" href="../assets/favicon.ico">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
-            <i class="fas fa-arrow-left" aria-hidden="true"></i>
-            <span>All tools</span>
-        </a>
-        <div class="top-bar__title"></div>
+        <a href="../index.html" class="brand">devtools</a>
+        <span class="top-bar__crumb-sep">/</span>
+        <span class="top-bar__crumb-current" id="tool-crumb"></span>
         <div class="toolbar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">

--- a/tools/text-diff.html
+++ b/tools/text-diff.html
@@ -11,7 +11,7 @@
     <link rel="stylesheet" href="../css/components.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
     <style>
         /* Diff specific styles */
@@ -105,14 +105,12 @@
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
-            <i class="fas fa-arrow-left" aria-hidden="true"></i>
-            <span>All tools</span>
-        </a>
-        <div class="top-bar__title"></div>
+        <a href="../index.html" class="brand">devtools</a>
+        <span class="top-bar__crumb-sep">/</span>
+        <span class="top-bar__crumb-current" id="tool-crumb"></span>
         <div class="toolbar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">

--- a/tools/timestamp-converter.html
+++ b/tools/timestamp-converter.html
@@ -11,20 +11,18 @@
     <link rel="stylesheet" href="../css/components.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
-            <i class="fas fa-arrow-left" aria-hidden="true"></i>
-            <span>All tools</span>
-        </a>
-        <div class="top-bar__title"></div>
+        <a href="../index.html" class="brand">devtools</a>
+        <span class="top-bar__crumb-sep">/</span>
+        <span class="top-bar__crumb-current" id="tool-crumb"></span>
         <div class="toolbar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">

--- a/tools/url-encoder-decoder.html
+++ b/tools/url-encoder-decoder.html
@@ -11,20 +11,18 @@
     <link rel="stylesheet" href="../css/components.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
-            <i class="fas fa-arrow-left" aria-hidden="true"></i>
-            <span>All tools</span>
-        </a>
-        <div class="top-bar__title"></div>
+        <a href="../index.html" class="brand">devtools</a>
+        <span class="top-bar__crumb-sep">/</span>
+        <span class="top-bar__crumb-current" id="tool-crumb"></span>
         <div class="toolbar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">

--- a/tools/url-parser.html
+++ b/tools/url-parser.html
@@ -11,20 +11,18 @@
     <link rel="stylesheet" href="../css/components.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
-            <i class="fas fa-arrow-left" aria-hidden="true"></i>
-            <span>All tools</span>
-        </a>
-        <div class="top-bar__title"></div>
+        <a href="../index.html" class="brand">devtools</a>
+        <span class="top-bar__crumb-sep">/</span>
+        <span class="top-bar__crumb-current" id="tool-crumb"></span>
         <div class="toolbar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">

--- a/tools/url-to-markdown.html
+++ b/tools/url-to-markdown.html
@@ -11,20 +11,18 @@
     <link rel="stylesheet" href="../css/components.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
-            <i class="fas fa-arrow-left" aria-hidden="true"></i>
-            <span>All tools</span>
-        </a>
-        <div class="top-bar__title"></div>
+        <a href="../index.html" class="brand">devtools</a>
+        <span class="top-bar__crumb-sep">/</span>
+        <span class="top-bar__crumb-current" id="tool-crumb"></span>
         <div class="toolbar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">

--- a/tools/uuid-generator.html
+++ b/tools/uuid-generator.html
@@ -11,20 +11,18 @@
     <link rel="stylesheet" href="../css/components.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap">
     <link rel="icon" href="../assets/favicon.ico" type="image/x-icon">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
-            <i class="fas fa-arrow-left" aria-hidden="true"></i>
-            <span>All tools</span>
-        </a>
-        <div class="top-bar__title"></div>
+        <a href="../index.html" class="brand">devtools</a>
+        <span class="top-bar__crumb-sep">/</span>
+        <span class="top-bar__crumb-current" id="tool-crumb"></span>
         <div class="toolbar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">

--- a/tools/vim-editor.html
+++ b/tools/vim-editor.html
@@ -11,7 +11,7 @@
     <link rel="stylesheet" href="../css/components.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap">
     <link rel="icon" href="../assets/favicon.svg" type="image/svg+xml">
     <link rel="icon" href="../assets/favicon-32x32.png" type="image/png" sizes="32x32">
     <!-- CodeMirror CSS -->
@@ -369,14 +369,12 @@
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a class="top-bar__back" href="../index.html" aria-label="Back to all tools">
-            <i class="fas fa-arrow-left" aria-hidden="true"></i>
-            <span>All tools</span>
-        </a>
-        <div class="top-bar__title"></div>
+        <a href="../index.html" class="brand">devtools</a>
+        <span class="top-bar__crumb-sep">/</span>
+        <span class="top-bar__crumb-current" id="tool-crumb"></span>
         <div class="toolbar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="btn btn--ghost btn--icon-sm" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">


### PR DESCRIPTION
## Summary

A follow-up to #5 that strips the AI-dashboard tells from the redesign and replaces them with a denser, monospace-forward, single-column layout.

- **Sidebar → category sections.** Tools are now grouped into numbered sections (`01 TEXT`, `02 ENCODING`, …) with a single merged-border grid. Search and Cmd/Ctrl+K still work; sections with no matching cards collapse while typing.
- **One accent.** The nine per-category colours, the gradient logo, the kbd badge, and the chip system are gone. A single vermilion (`#ff5b1f`) replaces the Tailwind-blue default.
- **JetBrains Mono throughout.** Inter is dropped.
- **Terminal touches.** `~devtools` brand mark, `$ 36 developer tools…` intro line, slugified breadcrumb in tool-page headers (e.g. `devtools / json-beautifier-minifier`), `$ no tools match…` empty state.
- **Pruned component layer.** Deleted `.skeleton`, `.switch`, `.panel`, `.card`, the warning/info alert variants, and the per-category chip styles — none were used by any tool page.
- **Tighter tokens.** Sharper corners (3 / 6 / 8 px), two shadows instead of five, denser type and spacing scales.
- **All 36 tool pages updated** with the new brand + breadcrumb header (filled in by `main.js` from the page `<h1>`).

Net diff: +1,115 / –1,929 (–814 lines).

## Test plan

- [ ] Open `index.html` — verify the section-grouped layout renders, search narrows the visible sections (`json` → only the Data section stays visible), Cmd/Ctrl+K focuses search, Esc clears it.
- [ ] Toggle the theme on the homepage and on at least 3 tool pages (`tools/json-formatter.html`, `tools/password-generator.html`, `tools/vim-editor.html`); confirm contrast and the orange accent both read well in light + dark.
- [ ] Resize to ≤768 px and ≤480 px; the grid collapses to a single column, the back-link label hides on the narrowest viewport.
- [ ] On `tools/json-formatter.html` paste invalid JSON; the error alert appears with the new red left-bar styling and is announced (it now has `role=alert` / `aria-live=polite`).
- [ ] Paste valid JSON, hit Beautify, then Copy — the clipboard copy works (previously broken because the code element used `textContent`, not `value`).
- [ ] Verify the breadcrumb at the top of each tool page shows the slugified tool name (no empty crumb).

https://claude.ai/code/session_01H5uqb6eqt5ZQnjuNHHQ1vT

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5uqb6eqt5ZQnjuNHHQ1vT)_