### PR TITLE
refactor(ui): simplify to narrow centered column + responsive pass

### DIFF
--- a/css/components.css
+++ b/css/components.css
@@ -1,6 +1,6 @@
 /* ============================================================
    Devtools — components
-   Minimal, opinionated. Legacy aliases keep old tool pages working.
+   Buttons, inputs, alerts. Legacy aliases for old tool pages.
    ============================================================ */
 
 /* ============================================================
@@ -18,8 +18,8 @@ button.secondary {
     padding: 0 var(--space-3);
     border-radius: var(--radius-sm);
     border: 1px solid var(--border-strong);
-    background-color: var(--surface-1);
-    color: var(--text-primary);
+    background-color: var(--bg);
+    color: var(--text);
     font-family: var(--font-mono);
     font-size: var(--text-xs);
     font-weight: 500;
@@ -35,13 +35,13 @@ button.secondary {
 .btn:hover:not(:disabled),
 button.primary:hover:not(:disabled),
 button.secondary:hover:not(:disabled) {
-    border-color: var(--text-primary);
+    border-color: var(--text);
 }
 
 .btn:focus-visible,
 button.primary:focus-visible,
 button.secondary:focus-visible {
-    outline: 1px solid var(--text-primary);
+    outline: 1px solid var(--text);
     outline-offset: 1px;
 }
 
@@ -52,12 +52,12 @@ button.secondary:disabled {
     cursor: not-allowed;
 }
 
-/* Primary — filled, sharp */
+/* Primary — filled */
 .btn--primary,
 button.primary {
-    background-color: var(--text-primary);
-    color: var(--bg-primary);
-    border-color: var(--text-primary);
+    background-color: var(--text);
+    color: var(--bg);
+    border-color: var(--text);
 }
 
 .btn--primary:hover:not(:disabled),
@@ -66,29 +66,16 @@ button.primary:hover:not(:disabled) {
     border-color: var(--button-hover);
 }
 
-/* Secondary keeps default look (subtle surface) */
+/* Secondary — subtle surface */
 button.secondary {
-    background-color: var(--surface-2);
+    background-color: var(--bg-secondary);
 }
 
 button.secondary:hover:not(:disabled) {
-    background-color: var(--surface-3);
+    background-color: var(--bg-tertiary);
 }
 
-/* Ghost */
-.btn--ghost {
-    background-color: transparent;
-    border-color: transparent;
-    color: var(--text-secondary);
-}
-
-.btn--ghost:hover:not(:disabled) {
-    background-color: var(--surface-2);
-    color: var(--text-primary);
-    border-color: transparent;
-}
-
-/* Icon-only */
+/* Icon-only legacy */
 .btn--icon,
 button.icon-button {
     width: 34px;
@@ -96,41 +83,11 @@ button.icon-button {
     padding: 0;
 }
 
-.btn--icon-sm {
-    width: 30px;
-    height: 30px;
-    padding: 0;
-}
-
-/* Copied feedback */
 .btn.copied,
 button.copied {
     background-color: var(--success) !important;
     border-color: var(--success) !important;
     color: #fff !important;
-}
-
-/* ============================================================
-   Input (component-class form)
-   ============================================================ */
-
-.input {
-    display: block;
-    width: 100%;
-    height: 34px;
-    padding: 0 var(--space-3);
-    border-radius: var(--radius-sm);
-    border: 1px solid var(--input-border);
-    background-color: var(--input-bg);
-    color: var(--text-primary);
-    font-family: var(--font-mono);
-    font-size: var(--text-sm);
-}
-
-.input:focus {
-    outline: 1px solid var(--text-primary);
-    outline-offset: -1px;
-    border-color: var(--text-primary);
 }
 
 /* ============================================================
@@ -151,9 +108,9 @@ button.copied {
     font-family: var(--font-mono);
     font-size: var(--text-xs);
     font-weight: 500;
-    color: var(--text-secondary);
+    color: var(--text-muted);
     text-transform: uppercase;
-    letter-spacing: 0.06em;
+    letter-spacing: 0.08em;
     margin-bottom: 0;
 }
 
@@ -168,27 +125,6 @@ button.copied {
     align-items: center;
     gap: var(--space-2);
     margin-top: var(--space-3);
-}
-
-.toolbar__spacer { flex: 1; }
-
-/* ============================================================
-   Chip (used sparingly — section count, status)
-   ============================================================ */
-
-.chip {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--space-1);
-    padding: 1px var(--space-2);
-    border-radius: var(--radius-sm);
-    background-color: var(--surface-2);
-    color: var(--text-secondary);
-    font-family: var(--font-mono);
-    font-size: var(--text-xs);
-    font-weight: 500;
-    line-height: 1.6;
-    border: 1px solid var(--border-color);
 }
 
 /* ============================================================
@@ -237,13 +173,7 @@ input[type="radio"] {
 
 /* ============================================================
    Legacy tool page styling
-   Adopt new look without touching markup.
    ============================================================ */
-
-.tool-content {
-    max-width: 980px;
-    margin: 0 auto;
-}
 
 .tool-content textarea,
 .tool-content input[type="text"],
@@ -253,8 +183,7 @@ input[type="radio"] {
 }
 
 .options-group {
-    background-color: var(--surface-1);
-    border: 1px solid var(--border-color);
+    border: 1px solid var(--border);
     border-radius: var(--radius-md);
     padding: var(--space-4);
     margin-bottom: var(--space-5);
@@ -265,9 +194,9 @@ input[type="radio"] {
     font-family: var(--font-mono);
     font-size: var(--text-xs);
     font-weight: 500;
-    color: var(--text-secondary);
+    color: var(--text-muted);
     text-transform: uppercase;
-    letter-spacing: 0.06em;
+    letter-spacing: 0.08em;
     margin-bottom: var(--space-3);
 }
 

--- a/css/layout.css
+++ b/css/layout.css
@@ -387,16 +387,89 @@ footer .container {
    Responsive
    ============================================================ */
 
-@media (max-width: 640px) {
+/* Tablet & narrow desktop — tighten the name column so the
+   description has more room to breathe. */
+@media (max-width: 880px) {
     .tool__link {
-        grid-template-columns: 1fr;
-        row-gap: var(--space-1);
+        grid-template-columns: minmax(0, 11rem) 1fr;
+        column-gap: var(--space-4);
     }
+    .tool-container {
+        padding-left: var(--space-4);
+        padding-right: var(--space-4);
+    }
+}
+
+/* Phones — stack the tool row, drop horizontal padding, bump
+   touch targets, ease in the search input height. */
+@media (max-width: 640px) {
+    body { font-size: 0.9375rem; }
+
     .top-bar,
     .page,
     .app-footer,
     footer {
         padding-left: var(--space-4);
         padding-right: var(--space-4);
+    }
+
+    .page { padding-top: var(--space-5); padding-bottom: var(--space-7); }
+
+    .intro { margin-bottom: var(--space-6); }
+    .intro h1 { font-size: var(--text-xl); }
+
+    .search { margin-bottom: var(--space-6); }
+    .search input { height: 44px; font-size: var(--text-base); }
+    .search__icon { left: var(--space-3); }
+
+    .section { margin-bottom: var(--space-6); }
+
+    .tool__link {
+        grid-template-columns: 1fr;
+        row-gap: 2px;
+        padding: var(--space-3) var(--space-2);
+        margin: 0 calc(var(--space-2) * -1);
+    }
+
+    .tool__name { font-size: var(--text-base); }
+    .tool__desc { font-size: var(--text-sm); }
+
+    /* Bigger tap targets for header buttons */
+    .icon-btn,
+    .theme-toggle-btn {
+        width: 40px;
+        height: 40px;
+    }
+
+    .tool-container {
+        padding: var(--space-5) var(--space-4) var(--space-7);
+    }
+    .tool-header h1 { font-size: var(--text-xl); }
+}
+
+/* Very narrow — pull padding in further so the row list reads cleanly. */
+@media (max-width: 380px) {
+    .top-bar,
+    .page,
+    .app-footer,
+    footer,
+    .tool-container {
+        padding-left: var(--space-3);
+        padding-right: var(--space-3);
+    }
+    .top-bar { gap: var(--space-2); }
+}
+
+/* Coarse pointers (touch devices regardless of width) — make
+   sure the small icon buttons in the header stay easy to hit. */
+@media (pointer: coarse) {
+    .icon-btn,
+    .theme-toggle-btn {
+        width: 40px;
+        height: 40px;
+    }
+    .search__clear {
+        width: 32px;
+        height: 32px;
     }
 }

--- a/css/layout.css
+++ b/css/layout.css
@@ -1,106 +1,45 @@
 /* ============================================================
    Devtools — layout
-   Single column. Sticky terminal-style top bar.
-   Tools grouped into sections with mono headers.
+   Narrow centered column. Plain row-list. No cards.
    ============================================================ */
 
 /* ============================================================
-   Top bar
+   Page shell
+   ============================================================ */
+
+.page {
+    flex: 1 0 auto;
+    width: 100%;
+    max-width: 720px;
+    margin: 0 auto;
+    padding: var(--space-7) var(--space-5) var(--space-9);
+}
+
+/* ============================================================
+   Top bar (minimal inline header)
    ============================================================ */
 
 .top-bar {
-    position: sticky;
-    top: 0;
-    z-index: 30;
+    width: 100%;
+    max-width: 720px;
+    margin: 0 auto;
+    padding: var(--space-5) var(--space-5) 0;
     display: flex;
     align-items: center;
     gap: var(--space-3);
-    padding: var(--space-3) var(--space-5);
-    background-color: var(--bg-primary);
-    border-bottom: 1px solid var(--border-color);
-    min-height: 56px;
 }
 
-.brand {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--space-2);
+.top-bar__brand {
     font-family: var(--font-mono);
     font-size: var(--text-sm);
     font-weight: 600;
-    color: var(--text-primary);
+    color: var(--text);
     letter-spacing: -0.01em;
 }
 
-.brand::before {
-    content: '~';
-    color: var(--accent);
-    font-weight: 700;
-}
+.top-bar__brand:hover { text-decoration: none; color: var(--text); }
 
-.top-bar__search {
-    flex: 1;
-    max-width: 480px;
-    position: relative;
-    margin-left: auto;
-}
-
-.top-bar__search-input {
-    width: 100%;
-    height: 34px;
-    padding: 0 var(--space-3) 0 var(--space-7);
-    border-radius: var(--radius-sm);
-    border: 1px solid var(--border-color);
-    background-color: var(--bg-primary);
-    color: var(--text-primary);
-    font-family: var(--font-mono);
-    font-size: var(--text-sm);
-    transition: border-color var(--duration-fast) var(--ease-out);
-}
-
-.top-bar__search-input::placeholder {
-    color: var(--text-muted);
-}
-
-.top-bar__search-input:hover {
-    border-color: var(--input-border-hover);
-}
-
-.top-bar__search-input:focus {
-    outline: 1px solid var(--text-primary);
-    outline-offset: -1px;
-    border-color: var(--text-primary);
-}
-
-.top-bar__search-icon {
-    position: absolute;
-    left: var(--space-3);
-    top: 50%;
-    transform: translateY(-50%);
-    color: var(--text-muted);
-    pointer-events: none;
-    font-size: var(--text-xs);
-}
-
-.top-bar__search-clear {
-    position: absolute;
-    right: var(--space-2);
-    top: 50%;
-    transform: translateY(-50%);
-    width: 22px;
-    height: 22px;
-    display: grid;
-    place-items: center;
-    border-radius: var(--radius-sm);
-    color: var(--text-muted);
-    font-size: var(--text-xs);
-    background: transparent;
-}
-
-.top-bar__search-clear:hover {
-    background-color: var(--surface-2);
-    color: var(--text-primary);
-}
+.top-bar__spacer { flex: 1; }
 
 .top-bar__actions {
     display: flex;
@@ -108,253 +47,238 @@
     gap: var(--space-1);
 }
 
-/* Theme toggle */
-.theme-toggle-btn {
-    width: 34px;
-    height: 34px;
+.icon-btn {
+    width: 32px;
+    height: 32px;
     display: inline-grid;
     place-items: center;
     border-radius: var(--radius-sm);
-    border: 1px solid transparent;
-    background-color: transparent;
-    color: var(--text-secondary);
-    transition: background-color var(--duration-fast) var(--ease-out),
-                color var(--duration-fast) var(--ease-out);
+    color: var(--text-muted);
+    background: transparent;
+    border: 0;
+    transition: color var(--duration-fast) var(--ease-out),
+                background-color var(--duration-fast) var(--ease-out);
 }
 
-.theme-toggle-btn:hover {
-    background-color: var(--surface-2);
-    color: var(--text-primary);
+.icon-btn:hover {
+    color: var(--text);
+    background-color: var(--bg-secondary);
+    text-decoration: none;
 }
 
-.theme-toggle-btn:focus-visible {
-    outline: 1px solid var(--text-primary);
+.icon-btn:focus-visible {
+    outline: 1px solid var(--text);
     outline-offset: 1px;
 }
 
-.theme-toggle-btn svg {
+.icon-btn svg {
     width: 16px;
     height: 16px;
 }
 
+.icon-btn .icon-sun { display: none; }
+.icon-btn .icon-moon { display: block; }
+[data-theme="dark"] .icon-btn .icon-sun { display: block; }
+[data-theme="dark"] .icon-btn .icon-moon { display: none; }
+
+.theme-toggle-btn {
+    width: 32px;
+    height: 32px;
+    display: inline-grid;
+    place-items: center;
+    border-radius: var(--radius-sm);
+    color: var(--text-muted);
+    background: transparent;
+    transition: color var(--duration-fast) var(--ease-out),
+                background-color var(--duration-fast) var(--ease-out);
+}
+
+.theme-toggle-btn:hover {
+    color: var(--text);
+    background-color: var(--bg-secondary);
+}
+
+.theme-toggle-btn:focus-visible {
+    outline: 1px solid var(--text);
+    outline-offset: 1px;
+}
+
+.theme-toggle-btn svg { width: 16px; height: 16px; }
 .theme-toggle-btn .icon-sun { display: none; }
 .theme-toggle-btn .icon-moon { display: block; }
 [data-theme="dark"] .theme-toggle-btn .icon-sun { display: block; }
 [data-theme="dark"] .theme-toggle-btn .icon-moon { display: none; }
 
-/* Tool-page back link */
-.top-bar__back {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--space-2);
-    height: 34px;
-    padding: 0 var(--space-3) 0 var(--space-2);
-    border-radius: var(--radius-sm);
-    color: var(--text-secondary);
-    font-family: var(--font-mono);
-    font-size: var(--text-sm);
-}
-
-.top-bar__back:hover {
-    background-color: var(--surface-2);
-    color: var(--text-primary);
-}
-
-.top-bar__crumb {
-    display: inline-flex;
-    align-items: center;
-    gap: var(--space-2);
-    font-family: var(--font-mono);
-    font-size: var(--text-sm);
-    color: var(--text-secondary);
-}
-
-.top-bar__crumb-sep {
-    color: var(--text-muted);
-}
-
-.top-bar__crumb-current {
-    color: var(--text-primary);
-}
-
 /* ============================================================
-   Content
+   Intro
    ============================================================ */
 
-.content {
-    flex: 1 0 auto;
-    padding: var(--space-7) var(--space-5) var(--space-9);
-}
-
-.content__inner {
-    max-width: 1100px;
-    margin: 0 auto;
-}
-
-/* Intro line (terminal-style) */
 .intro {
-    font-family: var(--font-mono);
-    font-size: var(--text-sm);
+    margin-bottom: var(--space-7);
+}
+
+.intro h1 {
+    font-size: var(--text-2xl);
+    font-weight: 700;
+    margin-bottom: var(--space-3);
+    letter-spacing: -0.02em;
+}
+
+.intro p {
     color: var(--text-secondary);
-    margin-bottom: var(--space-8);
     line-height: var(--leading-relaxed);
 }
 
-.intro__prompt {
-    color: var(--accent);
-    margin-right: var(--space-2);
-    user-select: none;
+/* ============================================================
+   Search
+   ============================================================ */
+
+.search {
+    position: relative;
+    margin-bottom: var(--space-7);
 }
 
-.intro__count {
-    color: var(--text-primary);
-    font-weight: 500;
+.search input {
+    width: 100%;
+    height: 38px;
+    padding: 0 var(--space-3) 0 var(--space-8);
+    border-radius: var(--radius-md);
+    border: 1px solid var(--border);
+    background-color: var(--bg);
+    color: var(--text);
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    transition: border-color var(--duration-fast) var(--ease-out);
+}
+
+.search input::placeholder { color: var(--text-muted); }
+
+.search input:hover { border-color: var(--input-border-hover); }
+
+.search input:focus {
+    outline: 1px solid var(--text);
+    outline-offset: -1px;
+    border-color: var(--text);
+}
+
+.search__icon {
+    position: absolute;
+    left: var(--space-3);
+    top: 50%;
+    transform: translateY(-50%);
+    color: var(--text-muted);
+    font-size: var(--text-xs);
+    pointer-events: none;
+}
+
+.search__clear {
+    position: absolute;
+    right: var(--space-2);
+    top: 50%;
+    transform: translateY(-50%);
+    width: 24px;
+    height: 24px;
+    display: grid;
+    place-items: center;
+    border-radius: var(--radius-sm);
+    color: var(--text-muted);
+    background: transparent;
+}
+
+.search__clear:hover {
+    background-color: var(--bg-secondary);
+    color: var(--text);
 }
 
 /* ============================================================
-   Category sections
+   Category section
    ============================================================ */
 
 .section {
-    margin-bottom: var(--space-8);
+    margin-bottom: var(--space-7);
 }
 
 .section[hidden] { display: none; }
 
-.section__header {
-    display: flex;
-    align-items: baseline;
-    gap: var(--space-3);
-    margin-bottom: var(--space-4);
-    padding-bottom: var(--space-2);
-    border-bottom: 1px solid var(--border-color);
-}
-
-.section__index {
-    font-family: var(--font-mono);
-    font-size: var(--text-xs);
-    color: var(--text-muted);
-    font-weight: 500;
-}
-
 .section__title {
     font-family: var(--font-mono);
-    font-size: var(--text-sm);
-    font-weight: 600;
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    color: var(--text-primary);
-}
-
-.section__count {
-    font-family: var(--font-mono);
     font-size: var(--text-xs);
+    font-weight: 500;
     color: var(--text-muted);
-    margin-left: auto;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    margin-bottom: var(--space-3);
+    padding-bottom: var(--space-2);
+    border-bottom: 1px solid var(--border);
 }
 
 /* ============================================================
-   Tool grid (dense)
+   Tool list — plain rows, no cards
    ============================================================ */
 
-.tool-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-    gap: 0;
-    border: 1px solid var(--border-color);
-    border-radius: var(--radius-md);
-    overflow: hidden;
-    background-color: var(--surface-1);
+.tool-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
 }
 
-/* ============================================================
-   Tool card — minimal, dense, no per-category color
-   ============================================================ */
+.tool {
+    display: block;
+}
 
-.tool-card {
-    position: relative;
+.tool[hidden] { display: none; }
+
+.tool__link {
     display: grid;
-    grid-template-columns: 28px 1fr;
-    column-gap: var(--space-3);
-    align-items: start;
-    padding: var(--space-4) var(--space-4);
-    background-color: var(--surface-1);
-    color: var(--text-primary);
-    border-right: 1px solid var(--border-color);
-    border-bottom: 1px solid var(--border-color);
-    cursor: pointer;
+    grid-template-columns: minmax(0, 13rem) 1fr;
+    column-gap: var(--space-5);
+    padding: var(--space-3) var(--space-3);
+    margin: 0 calc(var(--space-3) * -1);
+    border-radius: var(--radius-sm);
+    color: var(--text);
     transition: background-color var(--duration-fast) var(--ease-out);
 }
 
-.tool-card[hidden] { display: none; }
-
-.tool-card:hover {
-    background-color: var(--surface-2);
+.tool__link:hover {
+    background-color: var(--bg-secondary);
+    text-decoration: none;
 }
 
-.tool-card:focus-visible {
-    outline: 1px solid var(--text-primary);
+.tool__link:focus-visible {
+    outline: 1px solid var(--text);
     outline-offset: -1px;
-    z-index: 1;
 }
 
-.tool-card__icon {
-    width: 22px;
-    height: 22px;
-    display: grid;
-    place-items: center;
-    color: var(--text-muted);
-    font-size: 0.95rem;
-    margin-top: 2px;
-    transition: color var(--duration-fast) var(--ease-out);
-}
-
-.tool-card:hover .tool-card__icon {
-    color: var(--accent);
-}
-
-.tool-card__body { min-width: 0; }
-
-.tool-card__title {
+.tool__name {
     font-family: var(--font-mono);
     font-size: var(--text-sm);
-    font-weight: 600;
-    color: var(--text-primary);
-    margin: 0 0 var(--space-1);
-    line-height: 1.3;
-    overflow-wrap: break-word;
+    font-weight: 500;
+    color: var(--text);
 }
 
-.tool-card__desc {
-    font-family: var(--font-sans);
-    font-size: var(--text-xs);
+.tool__link:hover .tool__name { color: var(--accent); }
+
+.tool__desc {
+    font-size: var(--text-sm);
     color: var(--text-secondary);
     line-height: var(--leading-normal);
-    margin: 0;
-    display: -webkit-box;
-    -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
 }
 
 /* No results */
 .no-results-message {
-    padding: var(--space-9) var(--space-5);
-    text-align: center;
+    padding: var(--space-7) 0;
     font-family: var(--font-mono);
     font-size: var(--text-sm);
     color: var(--text-muted);
-    border: 1px dashed var(--border-color);
-    border-radius: var(--radius-md);
 }
 
 .no-results-message::before {
-    content: '$ ';
-    color: var(--accent);
+    content: '// ';
+    color: var(--text-muted);
 }
 
 /* ============================================================
-   Tool page layout
+   Tool page
    ============================================================ */
 
 .tool-page-shell {
@@ -365,28 +289,53 @@
 
 .tool-container {
     flex: 1 0 auto;
+    width: 100%;
+    max-width: 880px;
+    margin: 0 auto;
     padding: var(--space-7) var(--space-5) var(--space-9);
 }
 
 .tool-container .container {
-    max-width: 980px;
+    max-width: none;
+    padding: 0;
 }
 
 .tool-header {
-    margin-bottom: var(--space-4);
+    margin-bottom: var(--space-3);
 }
 
 .tool-header h1 {
     font-size: var(--text-2xl);
+    font-weight: 700;
+    letter-spacing: -0.02em;
     margin-bottom: var(--space-2);
 }
 
 .tool-description {
-    max-width: 720px;
+    max-width: 640px;
     margin: 0 0 var(--space-7);
     color: var(--text-secondary);
     font-size: var(--text-sm);
     line-height: var(--leading-relaxed);
+}
+
+.back-link {
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    color: var(--text-muted);
+    margin-bottom: var(--space-5);
+}
+
+.back-link:hover {
+    color: var(--text);
+    text-decoration: none;
+}
+
+.back-link::before {
+    content: '←';
 }
 
 /* ============================================================
@@ -396,22 +345,14 @@
 .app-footer,
 footer {
     flex-shrink: 0;
-    padding: var(--space-5);
-    border-top: 1px solid var(--border-color);
-    background-color: var(--bg-primary);
+    width: 100%;
+    max-width: 720px;
+    margin: 0 auto;
+    padding: var(--space-7) var(--space-5);
+    border-top: 1px solid var(--border);
     color: var(--text-muted);
     font-family: var(--font-mono);
     font-size: var(--text-xs);
-}
-
-.app-footer__inner {
-    max-width: 1100px;
-    margin: 0 auto;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    flex-wrap: wrap;
-    gap: var(--space-2);
 }
 
 .app-footer p,
@@ -427,46 +368,35 @@ footer a {
 
 .app-footer a:hover,
 footer a:hover {
-    color: var(--text-primary);
+    color: var(--text);
 }
 
-/* Legacy footer .container override */
 footer .container {
-    text-align: center;
+    padding: 0;
+    max-width: none;
 }
 
-/* Legacy tools-grid alias (still used by some pages) */
+/* Legacy tools-grid alias (unused on the new homepage) */
 .tools-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-    gap: var(--space-4);
+    grid-template-columns: 1fr;
+    gap: var(--space-3);
 }
 
 /* ============================================================
    Responsive
    ============================================================ */
 
-@media (max-width: 768px) {
-    .top-bar {
-        padding: var(--space-3) var(--space-4);
-        gap: var(--space-2);
-    }
-    .top-bar__search { max-width: none; }
-    .content {
-        padding: var(--space-5) var(--space-4) var(--space-7);
-    }
-    .tool-container {
-        padding: var(--space-5) var(--space-4) var(--space-7);
-    }
-    .tool-grid {
+@media (max-width: 640px) {
+    .tool__link {
         grid-template-columns: 1fr;
+        row-gap: var(--space-1);
     }
-    .app-footer__inner {
-        justify-content: center;
-        text-align: center;
+    .top-bar,
+    .page,
+    .app-footer,
+    footer {
+        padding-left: var(--space-4);
+        padding-right: var(--space-4);
     }
-}
-
-@media (max-width: 480px) {
-    .top-bar__back span { display: none; }
 }

--- a/css/styles.css
+++ b/css/styles.css
@@ -1,31 +1,28 @@
 /* ============================================================
-   Devtools — base styles & design tokens
-   Terminal-flavoured: mono-forward, dense, minimal chrome.
+   Devtools — tokens, reset, base typography
    ============================================================ */
 
 :root {
-    /* Fonts — mono is the primary identity */
     --font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
     --font-sans: -apple-system, BlinkMacSystemFont, 'Inter', 'Segoe UI', Roboto, sans-serif;
-    --font-display: var(--font-mono);
+    --font-display: var(--font-sans);
     --font-body: var(--font-sans);
-    --font-primary: var(--font-sans); /* legacy alias */
+    --font-primary: var(--font-sans);
 
-    /* Type scale (tighter) */
-    --text-xs: 0.75rem;     /* 12 */
-    --text-sm: 0.8125rem;   /* 13 */
-    --text-base: 0.9375rem; /* 15 */
-    --text-md: 1rem;        /* 16 */
-    --text-lg: 1.125rem;    /* 18 */
-    --text-xl: 1.375rem;    /* 22 */
-    --text-2xl: 1.75rem;    /* 28 */
-    --text-3xl: 2.25rem;    /* 36 */
+    /* Type scale */
+    --text-xs: 0.75rem;
+    --text-sm: 0.8125rem;
+    --text-base: 0.9375rem;
+    --text-md: 1rem;
+    --text-lg: 1.125rem;
+    --text-xl: 1.375rem;
+    --text-2xl: 1.75rem;
+    --text-3xl: 2.25rem;
     --leading-tight: 1.25;
-    --leading-normal: 1.5;
-    --leading-relaxed: 1.65;
+    --leading-normal: 1.55;
+    --leading-relaxed: 1.7;
 
-    /* Spacing (4px base, denser scale) */
-    --space-0: 0;
+    /* Spacing */
     --space-1: 0.25rem;
     --space-2: 0.5rem;
     --space-3: 0.75rem;
@@ -36,8 +33,6 @@
     --space-8: 2.5rem;
     --space-9: 3rem;
     --space-10: 4rem;
-
-    /* Legacy aliases */
     --spacing-xs: var(--space-1);
     --spacing-sm: var(--space-2);
     --spacing-md: var(--space-4);
@@ -45,29 +40,18 @@
     --spacing-xl: var(--space-6);
     --spacing-xxl: var(--space-8);
 
-    /* Radius — sharper. Just three. */
-    --radius-sm: 3px;
+    /* Radius */
+    --radius-sm: 4px;
     --radius-md: 6px;
     --radius-lg: 8px;
-    --border-radius: var(--radius-md); /* legacy */
-
-    /* Shadows — keep only two */
-    --shadow-sm: 0 1px 0 rgba(0, 0, 0, 0.04);
-    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
+    --border-radius: var(--radius-md);
 
     /* Motion */
     --ease-out: cubic-bezier(0.2, 0, 0, 1);
     --duration-fast: 100ms;
     --duration-base: 160ms;
     --transition-speed: var(--duration-base);
-
-    /* Focus ring */
-    --focus-ring: 0 0 0 2px var(--bg-primary), 0 0 0 4px var(--accent);
 }
-
-/* ============================================================
-   Reset
-   ============================================================ */
 
 *, *::before, *::after { box-sizing: border-box; }
 * { margin: 0; padding: 0; }
@@ -78,82 +62,58 @@ html, body { height: 100%; }
 body {
     font-family: var(--font-body);
     font-size: var(--text-base);
-    line-height: var(--leading-normal);
+    line-height: var(--leading-relaxed);
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     display: flex;
     flex-direction: column;
     min-height: 100vh;
-    background-color: var(--bg-primary);
-    color: var(--text-primary);
-    transition: background-color var(--duration-fast) var(--ease-out),
-                color var(--duration-fast) var(--ease-out);
+    background-color: var(--bg);
+    color: var(--text);
 }
 
-a { color: inherit; text-decoration: none; }
+a { color: var(--accent); text-decoration: none; }
+a:hover { text-decoration: underline; text-underline-offset: 3px; }
 button { cursor: pointer; font-family: inherit; font-size: inherit; border: 0; background: transparent; color: inherit; }
 input, textarea, select { font-family: inherit; font-size: inherit; color: inherit; }
-ul { list-style: none; }
+ul, ol { list-style: none; }
 img, svg { display: block; max-width: 100%; }
 
-/* Skip link */
+h1, h2, h3, h4, h5, h6 {
+    line-height: var(--leading-tight);
+    letter-spacing: -0.01em;
+    color: var(--text);
+    font-weight: 600;
+}
+h1 { font-size: var(--text-2xl); }
+h2 { font-size: var(--text-lg); }
+h3 { font-size: var(--text-md); }
+h4 { font-size: var(--text-base); }
+
+p { color: var(--text-secondary); }
+
+code, pre, kbd, samp { font-family: var(--font-mono); }
+
+::selection { background-color: var(--accent); color: var(--bg); }
+
+::-webkit-scrollbar { width: 10px; height: 10px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--border); border-radius: 5px; border: 2px solid var(--bg); }
+::-webkit-scrollbar-thumb:hover { background: var(--text-muted); }
+
 .skip-link {
     position: absolute;
     top: -40px;
     left: var(--space-4);
     padding: var(--space-2) var(--space-3);
-    background: var(--accent);
-    color: var(--accent-on);
+    background: var(--text);
+    color: var(--bg);
     font-family: var(--font-mono);
     font-size: var(--text-xs);
     border-radius: var(--radius-sm);
     z-index: 1000;
 }
 .skip-link:focus { top: var(--space-2); outline: none; }
-
-/* ============================================================
-   Typography
-   ============================================================ */
-
-h1, h2, h3, h4, h5, h6 {
-    font-family: var(--font-display);
-    line-height: var(--leading-tight);
-    color: var(--text-primary);
-    letter-spacing: -0.01em;
-    font-weight: 600;
-}
-
-h1 { font-size: var(--text-2xl); }
-h2 { font-size: var(--text-xl); }
-h3 { font-size: var(--text-lg); }
-h4 { font-size: var(--text-md); }
-h5 { font-size: var(--text-base); }
-h6 { font-size: var(--text-xs); text-transform: uppercase; letter-spacing: 0.08em; }
-
-p { color: var(--text-secondary); }
-
-code, pre, kbd, samp {
-    font-family: var(--font-mono);
-}
-
-::selection {
-    background-color: var(--accent);
-    color: var(--accent-on);
-}
-
-/* Scrollbar */
-::-webkit-scrollbar { width: 10px; height: 10px; }
-::-webkit-scrollbar-track { background: transparent; }
-::-webkit-scrollbar-thumb {
-    background: var(--border-color);
-    border-radius: 5px;
-    border: 2px solid var(--bg-primary);
-}
-::-webkit-scrollbar-thumb:hover { background: var(--border-strong); }
-
-/* ============================================================
-   Utility classes (kept small)
-   ============================================================ */
 
 .hidden { display: none !important; }
 .sr-only {
@@ -171,15 +131,14 @@ code, pre, kbd, samp {
 @media (prefers-reduced-motion: reduce) {
     *, *::before, *::after {
         animation-duration: 0.01ms !important;
-        animation-iteration-count: 1 !important;
         transition-duration: 0.01ms !important;
     }
 }
 
-/* Container — used by tool pages */
+/* Container — used by legacy tool pages */
 .container {
     width: 100%;
-    max-width: 1100px;
+    max-width: 720px;
     margin: 0 auto;
     padding: 0 var(--space-5);
 }

--- a/css/theme.css
+++ b/css/theme.css
@@ -1,131 +1,120 @@
 /* ============================================================
-   Devtools — theme (palette only)
-   One accent. Three surfaces. Real contrast. No gradients.
+   Devtools — palette
+   Quiet, monochrome with a single muted accent.
    ============================================================ */
 
 :root {
-    /* Surfaces */
-    --bg-primary: #fafaf9;
-    --bg-secondary: #ffffff;
-    --bg-tertiary: #f4f4f2;
+    --bg: #fafaf9;
+    --bg-secondary: #f4f4f2;
+    --bg-tertiary: #e8e8e4;
     --surface-1: #ffffff;
     --surface-2: #f4f4f2;
-    --surface-3: #eceae6;
+    --bg-primary: var(--bg); /* legacy */
 
-    /* Text */
-    --text-primary: #0a0a0a;
-    --text-secondary: #525252;
-    --text-muted: #8a8a87;
+    --text: #18181b;
+    --text-primary: var(--text);
+    --text-secondary: #52525b;
+    --text-muted: #a1a1aa;
 
-    /* Border */
-    --border-color: #e7e5e0;
-    --border-strong: #d4d2cd;
+    --border: #e4e4e7;
+    --border-strong: #d4d4d8;
+    --border-color: var(--border);
 
-    /* Accent — a single warm sharp color (not Tailwind blue) */
-    --accent: #ff5b1f;        /* deliberate vermilion */
-    --accent-hover: #e64d12;
-    --accent-on: #ffffff;
-    --accent-soft: rgba(255, 91, 31, 0.10);
-
-    /* Legacy aliases used by tool pages */
+    /* Muted dev-blog blue (not Tailwind blue, not vermilion). */
+    --accent: #2563eb;
+    --accent-hover: #1d4ed8;
+    --accent-soft: rgba(37, 99, 235, 0.10);
     --accent-primary: var(--accent);
     --accent-secondary: var(--accent-hover);
     --primary-color: var(--accent);
-    --primary-color-rgb: 255, 91, 31;
+    --primary-color-rgb: 37, 99, 235;
 
-    /* Semantic */
-    --success: #15803d;
+    --success: #16a34a;
     --success-bg: #ecfccb;
     --success-text: #166534;
-    --danger: #b91c1c;
+    --danger: #dc2626;
     --error-bg: #fee2e2;
     --error-text: #991b1b;
 
-    /* Inputs */
     --input-bg: #ffffff;
-    --input-border: #d4d2cd;
-    --input-border-hover: #a8a6a0;
-    --input-border-focus: var(--accent);
-    --input-border-focus: var(--text-primary);
+    --input-border: #d4d4d8;
+    --input-border-hover: #a1a1aa;
+    --input-border-focus: var(--text);
 
-    /* Buttons (legacy) */
-    --button-bg: var(--text-primary);
-    --button-text: #ffffff;
+    --button-bg: var(--text);
+    --button-text: var(--bg);
     --button-hover: #262626;
 
-    /* Code */
     --code-bg: #f4f4f2;
-    --code-text: var(--text-primary);
+    --code-text: var(--text);
 
-    /* Selection / scrollbar */
-    --selection-bg: var(--text-primary);
-    --selection-text: var(--bg-primary);
+    --selection-bg: var(--text);
+    --selection-text: var(--bg);
 }
 
 [data-theme="dark"] {
-    --bg-primary: #0d0d0c;
-    --bg-secondary: #121211;
-    --bg-tertiary: #1a1a18;
-    --surface-1: #121211;
-    --surface-2: #1a1a18;
-    --surface-3: #232320;
+    --bg: #0a0a0a;
+    --bg-secondary: #111111;
+    --bg-tertiary: #161616;
+    --surface-1: #111111;
+    --surface-2: #161616;
+    --bg-primary: var(--bg);
 
-    --text-primary: #f5f5f1;
-    --text-secondary: #a8a6a0;
-    --text-muted: #6f6e69;
+    --text: #f5f5f4;
+    --text-primary: var(--text);
+    --text-secondary: #a1a1aa;
+    --text-muted: #6b6b70;
 
-    --border-color: #232320;
-    --border-strong: #34332e;
+    --border: #1f1f22;
+    --border-strong: #2a2a2e;
+    --border-color: var(--border);
 
-    --accent: #ff7042;
-    --accent-hover: #ff8a62;
-    --accent-on: #0d0d0c;
-    --accent-soft: rgba(255, 112, 66, 0.12);
-
+    --accent: #60a5fa;
+    --accent-hover: #93c5fd;
+    --accent-soft: rgba(96, 165, 250, 0.12);
     --accent-primary: var(--accent);
     --accent-secondary: var(--accent-hover);
     --primary-color: var(--accent);
-    --primary-color-rgb: 255, 112, 66;
+    --primary-color-rgb: 96, 165, 250;
 
     --success: #4ade80;
-    --success-bg: rgba(74, 222, 128, 0.12);
+    --success-bg: rgba(74, 222, 128, 0.10);
     --success-text: #86efac;
     --danger: #f87171;
-    --error-bg: rgba(248, 113, 113, 0.12);
+    --error-bg: rgba(248, 113, 113, 0.10);
     --error-text: #fca5a5;
 
-    --input-bg: #121211;
-    --input-border: #2a2a26;
-    --input-border-hover: #3a3935;
-    --input-border-focus: var(--text-primary);
+    --input-bg: #111111;
+    --input-border: #2a2a2e;
+    --input-border-hover: #3a3a3e;
+    --input-border-focus: var(--text);
 
-    --button-bg: var(--text-primary);
-    --button-text: #0d0d0c;
+    --button-bg: var(--text);
+    --button-text: var(--bg);
     --button-hover: #e7e5e0;
 
-    --code-bg: #1a1a18;
-    --code-text: var(--text-primary);
+    --code-bg: #161616;
+    --code-text: var(--text);
 
     --selection-bg: var(--accent);
-    --selection-text: var(--accent-on);
+    --selection-text: var(--bg);
 }
 
-/* Theme application */
 a { color: var(--accent); }
 a:hover { color: var(--accent-hover); }
 
 hr {
     border: 0;
-    border-top: 1px solid var(--border-color);
+    border-top: 1px solid var(--border);
     margin: var(--space-6) 0;
 }
 
-/* Native form element baseline */
+/* Native form elements baseline */
 textarea, input[type="text"], input[type="number"], input[type="search"],
 input[type="password"], input[type="email"], input[type="url"], select {
     background-color: var(--input-bg);
     border: 1px solid var(--input-border);
-    color: var(--text-primary);
+    color: var(--text);
     border-radius: var(--radius-sm);
     padding: var(--space-2) var(--space-3);
     transition: border-color var(--duration-fast) var(--ease-out);
@@ -140,10 +129,9 @@ input[type="email"]:hover, input[type="url"]:hover, select:hover {
 textarea:focus, input[type="text"]:focus, input[type="number"]:focus,
 input[type="search"]:focus, input[type="password"]:focus,
 input[type="email"]:focus, input[type="url"]:focus, select:focus {
-    border-color: var(--text-primary);
-    box-shadow: none;
-    outline: 1px solid var(--text-primary);
+    outline: 1px solid var(--text);
     outline-offset: -1px;
+    border-color: var(--text);
 }
 
 textarea {
@@ -169,7 +157,7 @@ code {
 pre {
     padding: var(--space-4);
     overflow: auto;
-    border: 1px solid var(--border-color);
+    border: 1px solid var(--border);
     border-radius: var(--radius-md);
 }
 

--- a/index.html
+++ b/index.html
@@ -3,8 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="A collection of fast, offline-friendly developer utilities.">
-    <meta name="theme-color" content="#0d0d0c">
+    <meta name="description" content="A small collection of offline-friendly developer utilities.">
     <title>devtools</title>
     <link rel="stylesheet" href="css/styles.css">
     <link rel="stylesheet" href="css/theme.css">
@@ -15,23 +14,17 @@
     <link rel="apple-touch-icon" href="assets/apple-touch-icon.png">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&display=swap">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600&display=swap">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 </head>
 <body>
     <a class="skip-link" href="#tools">Skip to content</a>
 
     <header class="top-bar">
-        <a href="index.html" class="brand">devtools</a>
-        <div class="top-bar__search">
-            <i class="fas fa-search top-bar__search-icon" aria-hidden="true"></i>
-            <input type="search" id="tool-search" class="top-bar__search-input" placeholder="search" aria-label="Search tools" autocomplete="off" spellcheck="false">
-            <button type="button" id="search-clear" class="top-bar__search-clear hidden" aria-label="Clear search">
-                <i class="fas fa-times" aria-hidden="true"></i>
-            </button>
-        </div>
+        <a href="index.html" class="top-bar__brand">devtools</a>
+        <div class="top-bar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="icon-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
@@ -41,365 +34,120 @@
         </div>
     </header>
 
-    <main class="content" id="tools">
-        <div class="content__inner">
-            <p class="intro">
-                <span class="intro__prompt">$</span><span class="intro__count" id="tool-count">36</span> developer tools — offline, single-file, no tracking.
-            </p>
+    <main class="page" id="tools">
+        <section class="intro">
+            <h1>Developer tools</h1>
+            <p>A small collection of <span id="tool-count">36</span> offline-friendly utilities — text, encoding, data, web, crypto. Press <code>/</code> or <code>⌘K</code> to search.</p>
+        </section>
 
-            <section class="section" data-category="text">
-                <header class="section__header">
-                    <span class="section__index">01</span>
-                    <h2 class="section__title">Text</h2>
-                    <span class="section__count">6</span>
-                </header>
-                <div class="tool-grid">
-                    <a href="tools/string-case-converter.html" class="tool-card">
-                        <span class="tool-card__icon"><i class="fas fa-font" aria-hidden="true"></i></span>
-                        <div class="tool-card__body">
-                            <h3 class="tool-card__title">String Case Converter</h3>
-                            <p class="tool-card__desc">Convert between camelCase, snake_case, kebab-case and more</p>
-                        </div>
-                    </a>
-                    <a href="tools/line-sort-dedupe.html" class="tool-card">
-                        <span class="tool-card__icon"><i class="fas fa-sort-alpha-down" aria-hidden="true"></i></span>
-                        <div class="tool-card__body">
-                            <h3 class="tool-card__title">Line Sort &amp; Dedupe</h3>
-                            <p class="tool-card__desc">Sort lines alphabetically and remove duplicates</p>
-                        </div>
-                    </a>
-                    <a href="tools/backslash-escape-unescape.html" class="tool-card">
-                        <span class="tool-card__icon"><i class="fas fa-backspace" aria-hidden="true"></i></span>
-                        <div class="tool-card__body">
-                            <h3 class="tool-card__title">Backslash Escape</h3>
-                            <p class="tool-card__desc">Escape and unescape backslashes in text</p>
-                        </div>
-                    </a>
-                    <a href="tools/string-generator.html" class="tool-card">
-                        <span class="tool-card__icon"><i class="fas fa-random" aria-hidden="true"></i></span>
-                        <div class="tool-card__body">
-                            <h3 class="tool-card__title">Random String Generator</h3>
-                            <p class="tool-card__desc">Generate random strings with patterns and custom options</p>
-                        </div>
-                    </a>
-                    <a href="tools/text-diff.html" class="tool-card">
-                        <span class="tool-card__icon"><i class="fas fa-columns" aria-hidden="true"></i></span>
-                        <div class="tool-card__body">
-                            <h3 class="tool-card__title">Text Diff</h3>
-                            <p class="tool-card__desc">Compare two text blocks and highlight differences</p>
-                        </div>
-                    </a>
-                    <a href="tools/vim-editor.html" class="tool-card">
-                        <span class="tool-card__icon"><i class="fas fa-keyboard" aria-hidden="true"></i></span>
-                        <div class="tool-card__body">
-                            <h3 class="tool-card__title">Vim-Style Editor</h3>
-                            <p class="tool-card__desc">Browser-based text editor with Vim key bindings</p>
-                        </div>
-                    </a>
-                </div>
-            </section>
-
-            <section class="section" data-category="encoding">
-                <header class="section__header">
-                    <span class="section__index">02</span>
-                    <h2 class="section__title">Encoding</h2>
-                    <span class="section__count">3</span>
-                </header>
-                <div class="tool-grid">
-                    <a href="tools/base64-encoder-decoder.html" class="tool-card">
-                        <span class="tool-card__icon"><i class="fas fa-exchange-alt" aria-hidden="true"></i></span>
-                        <div class="tool-card__body">
-                            <h3 class="tool-card__title">Base64 Encoder</h3>
-                            <p class="tool-card__desc">Encode and decode text or files using Base64</p>
-                        </div>
-                    </a>
-                    <a href="tools/url-encoder-decoder.html" class="tool-card">
-                        <span class="tool-card__icon"><i class="fas fa-link" aria-hidden="true"></i></span>
-                        <div class="tool-card__body">
-                            <h3 class="tool-card__title">URL Encoder</h3>
-                            <p class="tool-card__desc">Encode and decode URLs and URL components</p>
-                        </div>
-                    </a>
-                    <a href="tools/ascii-hex-converter.html" class="tool-card">
-                        <span class="tool-card__icon"><i class="fas fa-exchange-alt" aria-hidden="true"></i></span>
-                        <div class="tool-card__body">
-                            <h3 class="tool-card__title">ASCII / HEX</h3>
-                            <p class="tool-card__desc">Convert between ASCII text and hexadecimal</p>
-                        </div>
-                    </a>
-                </div>
-            </section>
-
-            <section class="section" data-category="data">
-                <header class="section__header">
-                    <span class="section__index">03</span>
-                    <h2 class="section__title">Data</h2>
-                    <span class="section__count">6</span>
-                </header>
-                <div class="tool-grid">
-                    <a href="tools/json-formatter.html" class="tool-card">
-                        <span class="tool-card__icon"><i class="fas fa-code" aria-hidden="true"></i></span>
-                        <div class="tool-card__body">
-                            <h3 class="tool-card__title">JSON Formatter</h3>
-                            <p class="tool-card__desc">Beautify and minify JSON with syntax highlighting</p>
-                        </div>
-                    </a>
-                    <a href="tools/json-yaml-converter.html" class="tool-card">
-                        <span class="tool-card__icon"><i class="fas fa-sync-alt" aria-hidden="true"></i></span>
-                        <div class="tool-card__body">
-                            <h3 class="tool-card__title">JSON ↔ YAML</h3>
-                            <p class="tool-card__desc">Convert between JSON and YAML with validation</p>
-                        </div>
-                    </a>
-                    <a href="tools/csv-json-converter.html" class="tool-card">
-                        <span class="tool-card__icon"><i class="fas fa-file-code" aria-hidden="true"></i></span>
-                        <div class="tool-card__body">
-                            <h3 class="tool-card__title">CSV ↔ JSON</h3>
-                            <p class="tool-card__desc">Convert between CSV and JSON data formats</p>
-                        </div>
-                    </a>
-                    <a href="tools/csv-visualizer.html" class="tool-card">
-                        <span class="tool-card__icon"><i class="fas fa-table" aria-hidden="true"></i></span>
-                        <div class="tool-card__body">
-                            <h3 class="tool-card__title">CSV Visualizer</h3>
-                            <p class="tool-card__desc">Visualize CSV data as HTML tables with export</p>
-                        </div>
-                    </a>
-                    <a href="tools/json-to-protobuf.html" class="tool-card">
-                        <span class="tool-card__icon"><i class="fas fa-cube" aria-hidden="true"></i></span>
-                        <div class="tool-card__body">
-                            <h3 class="tool-card__title">JSON → Protobuf</h3>
-                            <p class="tool-card__desc">Generate Protocol Buffer definitions from JSON</p>
-                        </div>
-                    </a>
-                    <a href="tools/json-yaml-explorer.html" class="tool-card">
-                        <span class="tool-card__icon"><i class="fas fa-project-diagram" aria-hidden="true"></i></span>
-                        <div class="tool-card__body">
-                            <h3 class="tool-card__title">JSON/YAML Explorer</h3>
-                            <p class="tool-card__desc">Interactive tree view for JSON and YAML</p>
-                        </div>
-                    </a>
-                </div>
-            </section>
-
-            <section class="section" data-category="web">
-                <header class="section__header">
-                    <span class="section__index">04</span>
-                    <h2 class="section__title">Web</h2>
-                    <span class="section__count">4</span>
-                </header>
-                <div class="tool-grid">
-                    <a href="tools/url-parser.html" class="tool-card">
-                        <span class="tool-card__icon"><i class="fas fa-sitemap" aria-hidden="true"></i></span>
-                        <div class="tool-card__body">
-                            <h3 class="tool-card__title">URL Parser</h3>
-                            <p class="tool-card__desc">Parse and extract components from URLs</p>
-                        </div>
-                    </a>
-                    <a href="tools/curl-constructor.html" class="tool-card">
-                        <span class="tool-card__icon"><i class="fas fa-terminal" aria-hidden="true"></i></span>
-                        <div class="tool-card__body">
-                            <h3 class="tool-card__title">cURL Constructor</h3>
-                            <p class="tool-card__desc">Build cURL commands with customizable options</p>
-                        </div>
-                    </a>
-                    <a href="tools/jwt-decoder.html" class="tool-card">
-                        <span class="tool-card__icon"><i class="fas fa-key" aria-hidden="true"></i></span>
-                        <div class="tool-card__body">
-                            <h3 class="tool-card__title">JWT Decoder</h3>
-                            <p class="tool-card__desc">Decode and inspect JSON Web Tokens</p>
-                        </div>
-                    </a>
-                    <a href="tools/url-to-markdown.html" class="tool-card">
-                        <span class="tool-card__icon"><i class="fas fa-file-alt" aria-hidden="true"></i></span>
-                        <div class="tool-card__body">
-                            <h3 class="tool-card__title">URL → Markdown</h3>
-                            <p class="tool-card__desc">Scrape URL content and convert to Markdown</p>
-                        </div>
-                    </a>
-                </div>
-            </section>
-
-            <section class="section" data-category="crypto">
-                <header class="section__header">
-                    <span class="section__index">05</span>
-                    <h2 class="section__title">Crypto</h2>
-                    <span class="section__count">4</span>
-                </header>
-                <div class="tool-grid">
-                    <a href="tools/hash-generator.html" class="tool-card">
-                        <span class="tool-card__icon"><i class="fas fa-hashtag" aria-hidden="true"></i></span>
-                        <div class="tool-card__body">
-                            <h3 class="tool-card__title">Hash Generator</h3>
-                            <p class="tool-card__desc">MD5, SHA-1, SHA-256, SHA-512 hashes</p>
-                        </div>
-                    </a>
-                    <a href="tools/uuid-generator.html" class="tool-card">
-                        <span class="tool-card__icon"><i class="fas fa-fingerprint" aria-hidden="true"></i></span>
-                        <div class="tool-card__body">
-                            <h3 class="tool-card__title">UUID Generator</h3>
-                            <p class="tool-card__desc">Generate random UUIDs in version 4 format</p>
-                        </div>
-                    </a>
-                    <a href="tools/password-generator.html" class="tool-card">
-                        <span class="tool-card__icon"><i class="fas fa-lock" aria-hidden="true"></i></span>
-                        <div class="tool-card__body">
-                            <h3 class="tool-card__title">Password Generator</h3>
-                            <p class="tool-card__desc">Generate secure random passwords</p>
-                        </div>
-                    </a>
-                    <a href="tools/secret-share.html" class="tool-card">
-                        <span class="tool-card__icon"><i class="fas fa-user-secret" aria-hidden="true"></i></span>
-                        <div class="tool-card__body">
-                            <h3 class="tool-card__title">Secret Share</h3>
-                            <p class="tool-card__desc">Share encrypted messages with password protection</p>
-                        </div>
-                    </a>
-                </div>
-            </section>
-
-            <section class="section" data-category="time">
-                <header class="section__header">
-                    <span class="section__index">06</span>
-                    <h2 class="section__title">Time</h2>
-                    <span class="section__count">2</span>
-                </header>
-                <div class="tool-grid">
-                    <a href="tools/timestamp-converter.html" class="tool-card">
-                        <span class="tool-card__icon"><i class="fas fa-calendar-alt" aria-hidden="true"></i></span>
-                        <div class="tool-card__body">
-                            <h3 class="tool-card__title">Timestamp Converter</h3>
-                            <p class="tool-card__desc">Convert between timestamp formats and dates</p>
-                        </div>
-                    </a>
-                    <a href="tools/crontab-generator.html" class="tool-card">
-                        <span class="tool-card__icon"><i class="fas fa-clock" aria-hidden="true"></i></span>
-                        <div class="tool-card__body">
-                            <h3 class="tool-card__title">Crontab Generator</h3>
-                            <p class="tool-card__desc">Build crontab expressions with human-readable preview</p>
-                        </div>
-                    </a>
-                </div>
-            </section>
-
-            <section class="section" data-category="visual">
-                <header class="section__header">
-                    <span class="section__index">07</span>
-                    <h2 class="section__title">Visual</h2>
-                    <span class="section__count">6</span>
-                </header>
-                <div class="tool-grid">
-                    <a href="tools/color-converter.html" class="tool-card">
-                        <span class="tool-card__icon"><i class="fas fa-palette" aria-hidden="true"></i></span>
-                        <div class="tool-card__body">
-                            <h3 class="tool-card__title">Color Converter</h3>
-                            <p class="tool-card__desc">Convert between HEX, RGB, and HSL formats</p>
-                        </div>
-                    </a>
-                    <a href="tools/qr-code-tool.html" class="tool-card">
-                        <span class="tool-card__icon"><i class="fas fa-qrcode" aria-hidden="true"></i></span>
-                        <div class="tool-card__body">
-                            <h3 class="tool-card__title">QR Code Tool</h3>
-                            <p class="tool-card__desc">Generate and read QR codes from text or images</p>
-                        </div>
-                    </a>
-                    <a href="tools/markdown-preview.html" class="tool-card">
-                        <span class="tool-card__icon"><i class="fab fa-markdown" aria-hidden="true"></i></span>
-                        <div class="tool-card__body">
-                            <h3 class="tool-card__title">Markdown Preview</h3>
-                            <p class="tool-card__desc">Preview Markdown with live rendering</p>
-                        </div>
-                    </a>
-                    <a href="tools/mermaid-diagram-editor.html" class="tool-card">
-                        <span class="tool-card__icon"><i class="fas fa-project-diagram" aria-hidden="true"></i></span>
-                        <div class="tool-card__body">
-                            <h3 class="tool-card__title">Mermaid Editor</h3>
-                            <p class="tool-card__desc">Create diagrams with Mermaid syntax and live preview</p>
-                        </div>
-                    </a>
-                    <a href="tools/ocr-tool.html" class="tool-card">
-                        <span class="tool-card__icon"><i class="fas fa-eye" aria-hidden="true"></i></span>
-                        <div class="tool-card__body">
-                            <h3 class="tool-card__title">OCR Tool</h3>
-                            <p class="tool-card__desc">Extract text from images and PDFs offline</p>
-                        </div>
-                    </a>
-                    <a href="tools/ascii-art-generator.html" class="tool-card">
-                        <span class="tool-card__icon"><i class="fas fa-font" aria-hidden="true"></i></span>
-                        <div class="tool-card__body">
-                            <h3 class="tool-card__title">ASCII Art</h3>
-                            <p class="tool-card__desc">Generate ASCII art from text with multiple fonts</p>
-                        </div>
-                    </a>
-                </div>
-            </section>
-
-            <section class="section" data-category="api">
-                <header class="section__header">
-                    <span class="section__index">08</span>
-                    <h2 class="section__title">API</h2>
-                    <span class="section__count">2</span>
-                </header>
-                <div class="tool-grid">
-                    <a href="tools/api-mock-generator.html" class="tool-card">
-                        <span class="tool-card__icon"><i class="fas fa-vial" aria-hidden="true"></i></span>
-                        <div class="tool-card__body">
-                            <h3 class="tool-card__title">API Mock Data</h3>
-                            <p class="tool-card__desc">Generate realistic mock data for API testing</p>
-                        </div>
-                    </a>
-                    <a href="tools/regex-tester.html" class="tool-card">
-                        <span class="tool-card__icon"><i class="fas fa-search" aria-hidden="true"></i></span>
-                        <div class="tool-card__body">
-                            <h3 class="tool-card__title">Regex Tester</h3>
-                            <p class="tool-card__desc">Test and validate regular expressions live</p>
-                        </div>
-                    </a>
-                </div>
-            </section>
-
-            <section class="section" data-category="network">
-                <header class="section__header">
-                    <span class="section__index">09</span>
-                    <h2 class="section__title">Network</h2>
-                    <span class="section__count">3</span>
-                </header>
-                <div class="tool-grid">
-                    <a href="tools/ip-lookup.html" class="tool-card">
-                        <span class="tool-card__icon"><i class="fas fa-globe" aria-hidden="true"></i></span>
-                        <div class="tool-card__body">
-                            <h3 class="tool-card__title">IP Lookup</h3>
-                            <p class="tool-card__desc">Geolocation, ISP, and network details for any IP</p>
-                        </div>
-                    </a>
-                    <a href="tools/ssl-checker.html" class="tool-card">
-                        <span class="tool-card__icon"><i class="fas fa-shield-alt" aria-hidden="true"></i></span>
-                        <div class="tool-card__body">
-                            <h3 class="tool-card__title">SSL/TLS Checker</h3>
-                            <p class="tool-card__desc">Analyze certificates and security status for any domain</p>
-                        </div>
-                    </a>
-                    <a href="tools/subnet-calculator.html" class="tool-card">
-                        <span class="tool-card__icon"><i class="fas fa-network-wired" aria-hidden="true"></i></span>
-                        <div class="tool-card__body">
-                            <h3 class="tool-card__title">Subnet Calculator</h3>
-                            <p class="tool-card__desc">Compute subnet ranges from CIDR notation</p>
-                        </div>
-                    </a>
-                </div>
-            </section>
-
-            <div id="no-results-message" class="no-results-message hidden">
-                no tools match your search
-            </div>
+        <div class="search">
+            <i class="fas fa-search search__icon" aria-hidden="true"></i>
+            <input type="search" id="tool-search" placeholder="Search…" aria-label="Search tools" autocomplete="off" spellcheck="false">
+            <button type="button" id="search-clear" class="search__clear hidden" aria-label="Clear search">
+                <i class="fas fa-times" aria-hidden="true"></i>
+            </button>
         </div>
+
+        <section class="section">
+            <h2 class="section__title">Text</h2>
+            <ul class="tool-list">
+                <li class="tool"><a href="tools/string-case-converter.html" class="tool__link"><span class="tool__name">string-case-converter</span><span class="tool__desc">camelCase, snake_case, kebab-case and more</span></a></li>
+                <li class="tool"><a href="tools/line-sort-dedupe.html" class="tool__link"><span class="tool__name">line-sort-dedupe</span><span class="tool__desc">Sort lines alphabetically and remove duplicates</span></a></li>
+                <li class="tool"><a href="tools/backslash-escape-unescape.html" class="tool__link"><span class="tool__name">backslash-escape</span><span class="tool__desc">Escape and unescape backslashes in text</span></a></li>
+                <li class="tool"><a href="tools/string-generator.html" class="tool__link"><span class="tool__name">random-string</span><span class="tool__desc">Generate random strings with patterns</span></a></li>
+                <li class="tool"><a href="tools/text-diff.html" class="tool__link"><span class="tool__name">text-diff</span><span class="tool__desc">Compare two text blocks and highlight differences</span></a></li>
+                <li class="tool"><a href="tools/vim-editor.html" class="tool__link"><span class="tool__name">vim-editor</span><span class="tool__desc">In-browser text editor with Vim key bindings</span></a></li>
+            </ul>
+        </section>
+
+        <section class="section">
+            <h2 class="section__title">Encoding</h2>
+            <ul class="tool-list">
+                <li class="tool"><a href="tools/base64-encoder-decoder.html" class="tool__link"><span class="tool__name">base64</span><span class="tool__desc">Encode and decode Base64 (text or files)</span></a></li>
+                <li class="tool"><a href="tools/url-encoder-decoder.html" class="tool__link"><span class="tool__name">url-encode</span><span class="tool__desc">Encode and decode URLs and URL components</span></a></li>
+                <li class="tool"><a href="tools/ascii-hex-converter.html" class="tool__link"><span class="tool__name">ascii-hex</span><span class="tool__desc">Convert between ASCII text and hexadecimal</span></a></li>
+            </ul>
+        </section>
+
+        <section class="section">
+            <h2 class="section__title">Data</h2>
+            <ul class="tool-list">
+                <li class="tool"><a href="tools/json-formatter.html" class="tool__link"><span class="tool__name">json-formatter</span><span class="tool__desc">Beautify and minify JSON with syntax highlighting</span></a></li>
+                <li class="tool"><a href="tools/json-yaml-converter.html" class="tool__link"><span class="tool__name">json-yaml</span><span class="tool__desc">Convert between JSON and YAML with validation</span></a></li>
+                <li class="tool"><a href="tools/csv-json-converter.html" class="tool__link"><span class="tool__name">csv-json</span><span class="tool__desc">Convert between CSV and JSON</span></a></li>
+                <li class="tool"><a href="tools/csv-visualizer.html" class="tool__link"><span class="tool__name">csv-visualizer</span><span class="tool__desc">Visualize CSV data as HTML tables</span></a></li>
+                <li class="tool"><a href="tools/json-to-protobuf.html" class="tool__link"><span class="tool__name">json-to-protobuf</span><span class="tool__desc">Generate .proto definitions from JSON examples</span></a></li>
+                <li class="tool"><a href="tools/json-yaml-explorer.html" class="tool__link"><span class="tool__name">json-yaml-explorer</span><span class="tool__desc">Interactive tree view for JSON and YAML</span></a></li>
+            </ul>
+        </section>
+
+        <section class="section">
+            <h2 class="section__title">Web</h2>
+            <ul class="tool-list">
+                <li class="tool"><a href="tools/url-parser.html" class="tool__link"><span class="tool__name">url-parser</span><span class="tool__desc">Parse and extract components from URLs</span></a></li>
+                <li class="tool"><a href="tools/curl-constructor.html" class="tool__link"><span class="tool__name">curl-constructor</span><span class="tool__desc">Build cURL commands with customizable options</span></a></li>
+                <li class="tool"><a href="tools/jwt-decoder.html" class="tool__link"><span class="tool__name">jwt-decoder</span><span class="tool__desc">Decode and inspect JSON Web Tokens</span></a></li>
+                <li class="tool"><a href="tools/url-to-markdown.html" class="tool__link"><span class="tool__name">url-to-markdown</span><span class="tool__desc">Scrape a URL and convert content to Markdown</span></a></li>
+            </ul>
+        </section>
+
+        <section class="section">
+            <h2 class="section__title">Crypto</h2>
+            <ul class="tool-list">
+                <li class="tool"><a href="tools/hash-generator.html" class="tool__link"><span class="tool__name">hash</span><span class="tool__desc">MD5, SHA-1, SHA-256, SHA-512 hashes</span></a></li>
+                <li class="tool"><a href="tools/uuid-generator.html" class="tool__link"><span class="tool__name">uuid</span><span class="tool__desc">Generate random UUIDs (v4)</span></a></li>
+                <li class="tool"><a href="tools/password-generator.html" class="tool__link"><span class="tool__name">password</span><span class="tool__desc">Generate secure random passwords</span></a></li>
+                <li class="tool"><a href="tools/secret-share.html" class="tool__link"><span class="tool__name">secret-share</span><span class="tool__desc">Share encrypted messages with password protection</span></a></li>
+            </ul>
+        </section>
+
+        <section class="section">
+            <h2 class="section__title">Time</h2>
+            <ul class="tool-list">
+                <li class="tool"><a href="tools/timestamp-converter.html" class="tool__link"><span class="tool__name">timestamp</span><span class="tool__desc">Convert between timestamp formats and dates</span></a></li>
+                <li class="tool"><a href="tools/crontab-generator.html" class="tool__link"><span class="tool__name">crontab</span><span class="tool__desc">Build crontab expressions with human-readable preview</span></a></li>
+            </ul>
+        </section>
+
+        <section class="section">
+            <h2 class="section__title">Visual</h2>
+            <ul class="tool-list">
+                <li class="tool"><a href="tools/color-converter.html" class="tool__link"><span class="tool__name">color-converter</span><span class="tool__desc">Convert between HEX, RGB and HSL</span></a></li>
+                <li class="tool"><a href="tools/qr-code-tool.html" class="tool__link"><span class="tool__name">qr-code</span><span class="tool__desc">Generate and read QR codes</span></a></li>
+                <li class="tool"><a href="tools/markdown-preview.html" class="tool__link"><span class="tool__name">markdown-preview</span><span class="tool__desc">Preview Markdown with live rendering</span></a></li>
+                <li class="tool"><a href="tools/mermaid-diagram-editor.html" class="tool__link"><span class="tool__name">mermaid</span><span class="tool__desc">Create diagrams with Mermaid syntax</span></a></li>
+                <li class="tool"><a href="tools/ocr-tool.html" class="tool__link"><span class="tool__name">ocr</span><span class="tool__desc">Extract text from images and PDFs offline</span></a></li>
+                <li class="tool"><a href="tools/ascii-art-generator.html" class="tool__link"><span class="tool__name">ascii-art</span><span class="tool__desc">Generate ASCII art from text</span></a></li>
+            </ul>
+        </section>
+
+        <section class="section">
+            <h2 class="section__title">API</h2>
+            <ul class="tool-list">
+                <li class="tool"><a href="tools/api-mock-generator.html" class="tool__link"><span class="tool__name">api-mock</span><span class="tool__desc">Generate realistic mock data for API testing</span></a></li>
+                <li class="tool"><a href="tools/regex-tester.html" class="tool__link"><span class="tool__name">regex-tester</span><span class="tool__desc">Test and validate regular expressions live</span></a></li>
+            </ul>
+        </section>
+
+        <section class="section">
+            <h2 class="section__title">Network</h2>
+            <ul class="tool-list">
+                <li class="tool"><a href="tools/ip-lookup.html" class="tool__link"><span class="tool__name">ip-lookup</span><span class="tool__desc">Geolocation, ISP and network details for an IP</span></a></li>
+                <li class="tool"><a href="tools/ssl-checker.html" class="tool__link"><span class="tool__name">ssl-checker</span><span class="tool__desc">Analyze SSL/TLS certificates for any domain</span></a></li>
+                <li class="tool"><a href="tools/subnet-calculator.html" class="tool__link"><span class="tool__name">subnet</span><span class="tool__desc">Compute subnet ranges from CIDR notation</span></a></li>
+            </ul>
+        </section>
+
+        <p id="no-results-message" class="no-results-message hidden">no tools match</p>
     </main>
 
     <footer class="app-footer">
-        <div class="app-footer__inner">
-            <p>&copy; <span id="current-year">2025</span> devtools · <a href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener">source</a> · <a href="https://github.com/irfansofyana/Devtools/issues" target="_blank" rel="noopener">issues</a></p>
-            <p>built by <a href="https://github.com/irfansofyana" target="_blank" rel="noopener">irfansofyana</a></p>
-        </div>
+        <p>
+            &copy; <span id="current-year">2025</span> ·
+            <a href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener">source</a> ·
+            <a href="https://github.com/irfansofyana/Devtools/issues" target="_blank" rel="noopener">issues</a> ·
+            built by <a href="https://github.com/irfansofyana" target="_blank" rel="noopener">irfansofyana</a>
+        </p>
     </footer>
 
     <script src="js/theme.js"></script>

--- a/js/main.js
+++ b/js/main.js
@@ -1,83 +1,31 @@
 /**
  * Devtools — shared utilities.
- *
- * Exposes:
- *   showError(message, elementId)    — display dismissable error
- *   showSuccess(message, elementId)  — display dismissable success
- *   downloadTextFile(content, name)  — trigger a file download
- *   copyToClipboard(text, btn)       — programmatic copy with button feedback
- *
- * Tool pages can opt-in by:
- *   - giving a button `data-copy="<targetId>"`; the click handler reads the
- *     value of an <input>/<textarea>, OR the textContent of any other element
- *     (e.g. <pre>, <code>) and copies it.
- *
- * The previous implementation only supported `.value`, which silently copied
- * empty strings when the target was a <code> element (e.g. JSON formatter).
  */
 document.addEventListener('DOMContentLoaded', () => {
-    const currentYearElement = document.getElementById('current-year');
-    if (currentYearElement) {
-        currentYearElement.textContent = new Date().getFullYear();
-    }
-
-    populateToolPageTitle();
+    const yearEl = document.getElementById('current-year');
+    if (yearEl) yearEl.textContent = new Date().getFullYear();
     initCopyToClipboard();
 });
 
-/**
- * On tool pages, slugify the page <h1> into the top-bar breadcrumb slot.
- * (e.g. "JSON Beautifier/Minifier" -> "json-beautifier-minifier")
- */
-function populateToolPageTitle() {
-    const slot = document.getElementById('tool-crumb');
-    if (!slot || slot.textContent.trim()) return;
-    const h1 = document.querySelector('.tool-header h1, main h1');
-    if (!h1) return;
-    slot.textContent = h1.textContent
-        .trim()
-        .toLowerCase()
-        .replace(/[^a-z0-9]+/g, '-')
-        .replace(/^-|-$/g, '');
-}
-
-/**
- * Initialise the global delegated click handler for `[data-copy]` buttons.
- */
 function initCopyToClipboard() {
     document.addEventListener('click', (e) => {
         const trigger = e.target.closest('[data-copy]');
         if (!trigger) return;
-
         const target = document.getElementById(trigger.dataset.copy);
         if (!target) return;
-
         const text = readCopyableText(target);
         if (!text) return;
-
         copyToClipboard(text, trigger);
     });
 }
 
-/**
- * Read text from any element type (input, textarea, code/pre, generic block).
- * @param {HTMLElement} el
- * @returns {string}
- */
 function readCopyableText(el) {
     if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
         return el.value || '';
     }
-    // <pre>, <code>, <div>, etc.
     return el.innerText || el.textContent || '';
 }
 
-/**
- * Copy a string to clipboard and show a brief "Copied!" state on the button.
- * @param {string} text
- * @param {HTMLElement} [btn]
- * @returns {Promise<boolean>}
- */
 function copyToClipboard(text, btn) {
     const finish = (ok) => {
         if (!btn) return;
@@ -89,7 +37,6 @@ function copyToClipboard(text, btn) {
             btn.classList.remove('copied');
         }, 1800);
     };
-
     if (navigator.clipboard && navigator.clipboard.writeText) {
         return navigator.clipboard.writeText(text)
             .then(() => { finish(true); return true; })
@@ -112,10 +59,6 @@ function fallbackCopy(text) {
     document.body.removeChild(ta);
 }
 
-/**
- * Show an error message inside an alert element (auto-hides after 5s).
- * Wraps the message in an alert--error look automatically.
- */
 function showError(message, elementId) {
     const el = document.getElementById(elementId);
     if (!el) return;
@@ -128,9 +71,6 @@ function showError(message, elementId) {
     el._hideTimer = setTimeout(() => el.classList.add('hidden'), 5000);
 }
 
-/**
- * Show a success message inside an alert element (auto-hides after 5s).
- */
 function showSuccess(message, elementId) {
     const el = document.getElementById(elementId);
     if (!el) return;
@@ -143,9 +83,6 @@ function showSuccess(message, elementId) {
     el._hideTimer = setTimeout(() => el.classList.add('hidden'), 5000);
 }
 
-/**
- * Trigger a download of a text blob.
- */
 function downloadTextFile(content, filename, mimeType = 'text/plain') {
     const blob = new Blob([content], { type: mimeType });
     const url = URL.createObjectURL(blob);

--- a/js/search.js
+++ b/js/search.js
@@ -1,9 +1,8 @@
 /**
  * Devtools — homepage search.
- *
- * - Filters tool cards by query (matches title + description).
- * - Hides entire sections that have no matching cards.
- * - Ctrl/Cmd+K focuses search; Esc clears it.
+ * - Filters tool rows by query (matches name + description).
+ * - Hides sections that have no matching rows.
+ * - Ctrl/Cmd+K or "/" focuses the search input. Esc clears it.
  */
 
 document.addEventListener('DOMContentLoaded', () => {
@@ -13,26 +12,24 @@ document.addEventListener('DOMContentLoaded', () => {
     const noResults = document.getElementById('no-results-message');
     if (!input || sections.length === 0) return;
 
-    const cards = sections.flatMap(s => Array.from(s.querySelectorAll('.tool-card')));
+    const tools = sections.flatMap(s => Array.from(s.querySelectorAll('.tool')));
 
     function applyFilter(q) {
         const query = q.trim().toLowerCase();
         let totalVisible = 0;
 
         sections.forEach(section => {
-            const sectionCards = Array.from(section.querySelectorAll('.tool-card'));
-            let visibleInSection = 0;
-
-            sectionCards.forEach(card => {
-                const title = card.querySelector('.tool-card__title')?.textContent.toLowerCase() || '';
-                const desc = card.querySelector('.tool-card__desc')?.textContent.toLowerCase() || '';
-                const match = query === '' || title.includes(query) || desc.includes(query);
-                card.hidden = !match;
-                if (match) visibleInSection++;
+            const rows = Array.from(section.querySelectorAll('.tool'));
+            let visible = 0;
+            rows.forEach(row => {
+                const name = row.querySelector('.tool__name')?.textContent.toLowerCase() || '';
+                const desc = row.querySelector('.tool__desc')?.textContent.toLowerCase() || '';
+                const match = query === '' || name.includes(query) || desc.includes(query);
+                row.hidden = !match;
+                if (match) visible++;
             });
-
-            section.hidden = visibleInSection === 0;
-            totalVisible += visibleInSection;
+            section.hidden = visible === 0;
+            totalVisible += visible;
         });
 
         if (noResults) noResults.classList.toggle('hidden', totalVisible !== 0);
@@ -52,12 +49,25 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     document.addEventListener('keydown', (e) => {
+        const target = e.target;
+        const isTyping = target instanceof HTMLInputElement
+            || target instanceof HTMLTextAreaElement
+            || target?.isContentEditable;
+
         const isMac = navigator.platform.toUpperCase().includes('MAC');
         if ((isMac ? e.metaKey : e.ctrlKey) && e.key.toLowerCase() === 'k') {
             e.preventDefault();
             input.focus();
             input.select();
+            return;
         }
+
+        if (e.key === '/' && !isTyping) {
+            e.preventDefault();
+            input.focus();
+            return;
+        }
+
         if (e.key === 'Escape' && document.activeElement === input) {
             input.value = '';
             clearBtn?.classList.add('hidden');
@@ -67,5 +77,5 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     const countEl = document.getElementById('tool-count');
-    if (countEl) countEl.textContent = String(cards.length);
+    if (countEl) countEl.textContent = String(tools.length);
 });

--- a/tools/api-mock-generator.html
+++ b/tools/api-mock-generator.html
@@ -318,12 +318,10 @@
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a href="../index.html" class="brand">devtools</a>
-        <span class="top-bar__crumb-sep">/</span>
-        <span class="top-bar__crumb-current" id="tool-crumb"></span>
-        <div class="toolbar__spacer"></div>
+        <a href="../index.html" class="top-bar__brand">devtools</a>
+        <div class="top-bar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="icon-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
@@ -336,6 +334,7 @@
     <main>
         <section class="tool-container">
             <div class="container">
+                <a href="../index.html" class="back-link">all tools</a>
                 <div class="tool-header">
                     <h1>API Mock Data Generator</h1>
                 </div>

--- a/tools/ascii-art-generator.html
+++ b/tools/ascii-art-generator.html
@@ -17,12 +17,10 @@
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a href="../index.html" class="brand">devtools</a>
-        <span class="top-bar__crumb-sep">/</span>
-        <span class="top-bar__crumb-current" id="tool-crumb"></span>
-        <div class="toolbar__spacer"></div>
+        <a href="../index.html" class="top-bar__brand">devtools</a>
+        <div class="top-bar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="icon-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
@@ -35,6 +33,7 @@
     <main>
         <section class="tool-container">
             <div class="container">
+                <a href="../index.html" class="back-link">all tools</a>
                 <div class="tool-header">
                     <h1>ASCII Art Generator</h1>
                 </div>

--- a/tools/ascii-hex-converter.html
+++ b/tools/ascii-hex-converter.html
@@ -19,12 +19,10 @@
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a href="../index.html" class="brand">devtools</a>
-        <span class="top-bar__crumb-sep">/</span>
-        <span class="top-bar__crumb-current" id="tool-crumb"></span>
-        <div class="toolbar__spacer"></div>
+        <a href="../index.html" class="top-bar__brand">devtools</a>
+        <div class="top-bar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="icon-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
@@ -37,6 +35,7 @@
     <main>
         <section class="tool-container">
             <div class="container">
+                <a href="../index.html" class="back-link">all tools</a>
                 <div class="tool-header">
                     <h1>ASCII <> HEX Converter</h1>
                 </div>

--- a/tools/backslash-escape-unescape.html
+++ b/tools/backslash-escape-unescape.html
@@ -17,12 +17,10 @@
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a href="../index.html" class="brand">devtools</a>
-        <span class="top-bar__crumb-sep">/</span>
-        <span class="top-bar__crumb-current" id="tool-crumb"></span>
-        <div class="toolbar__spacer"></div>
+        <a href="../index.html" class="top-bar__brand">devtools</a>
+        <div class="top-bar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="icon-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
@@ -35,6 +33,7 @@
     <main>
         <section class="tool-container">
             <div class="container">
+                <a href="../index.html" class="back-link">all tools</a>
                 <div class="tool-header">
                     <h1>Backslash Escape/Unescape</h1>
                 </div>

--- a/tools/base64-encoder-decoder.html
+++ b/tools/base64-encoder-decoder.html
@@ -17,12 +17,10 @@
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a href="../index.html" class="brand">devtools</a>
-        <span class="top-bar__crumb-sep">/</span>
-        <span class="top-bar__crumb-current" id="tool-crumb"></span>
-        <div class="toolbar__spacer"></div>
+        <a href="../index.html" class="top-bar__brand">devtools</a>
+        <div class="top-bar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="icon-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
@@ -35,6 +33,7 @@
     <main>
         <section class="tool-container">
             <div class="container">
+                <a href="../index.html" class="back-link">all tools</a>
                 <div class="tool-header">
                     <h1>Base64 Encoder/Decoder</h1>
                 </div>

--- a/tools/color-converter.html
+++ b/tools/color-converter.html
@@ -17,12 +17,10 @@
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a href="../index.html" class="brand">devtools</a>
-        <span class="top-bar__crumb-sep">/</span>
-        <span class="top-bar__crumb-current" id="tool-crumb"></span>
-        <div class="toolbar__spacer"></div>
+        <a href="../index.html" class="top-bar__brand">devtools</a>
+        <div class="top-bar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="icon-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
@@ -35,6 +33,7 @@
     <main>
         <section class="tool-container">
             <div class="container">
+                <a href="../index.html" class="back-link">all tools</a>
                 <div class="tool-header">
                     <h1>Color Converter</h1>
                 </div>

--- a/tools/crontab-generator.html
+++ b/tools/crontab-generator.html
@@ -17,12 +17,10 @@
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a href="../index.html" class="brand">devtools</a>
-        <span class="top-bar__crumb-sep">/</span>
-        <span class="top-bar__crumb-current" id="tool-crumb"></span>
-        <div class="toolbar__spacer"></div>
+        <a href="../index.html" class="top-bar__brand">devtools</a>
+        <div class="top-bar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="icon-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
@@ -35,6 +33,7 @@
     <main>
         <section class="tool-container">
             <div class="container">
+                <a href="../index.html" class="back-link">all tools</a>
                 <div class="tool-header">
                     <h1>Crontab Generator</h1>
                 </div>

--- a/tools/csv-json-converter.html
+++ b/tools/csv-json-converter.html
@@ -17,12 +17,10 @@
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a href="../index.html" class="brand">devtools</a>
-        <span class="top-bar__crumb-sep">/</span>
-        <span class="top-bar__crumb-current" id="tool-crumb"></span>
-        <div class="toolbar__spacer"></div>
+        <a href="../index.html" class="top-bar__brand">devtools</a>
+        <div class="top-bar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="icon-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
@@ -35,6 +33,7 @@
     <main>
         <section class="tool-container">
             <div class="container">
+                <a href="../index.html" class="back-link">all tools</a>
                 <div class="tool-header">
                     <h1>CSV <> JSON Converter</h1>
                 </div>

--- a/tools/csv-visualizer.html
+++ b/tools/csv-visualizer.html
@@ -18,12 +18,10 @@
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a href="../index.html" class="brand">devtools</a>
-        <span class="top-bar__crumb-sep">/</span>
-        <span class="top-bar__crumb-current" id="tool-crumb"></span>
-        <div class="toolbar__spacer"></div>
+        <a href="../index.html" class="top-bar__brand">devtools</a>
+        <div class="top-bar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="icon-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
@@ -36,6 +34,7 @@
     <main>
         <section class="tool-container">
             <div class="container">
+                <a href="../index.html" class="back-link">all tools</a>
                 <div class="tool-header">
                     <h1>CSV Visualizer</h1>
                 </div>

--- a/tools/curl-constructor.html
+++ b/tools/curl-constructor.html
@@ -17,12 +17,10 @@
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a href="../index.html" class="brand">devtools</a>
-        <span class="top-bar__crumb-sep">/</span>
-        <span class="top-bar__crumb-current" id="tool-crumb"></span>
-        <div class="toolbar__spacer"></div>
+        <a href="../index.html" class="top-bar__brand">devtools</a>
+        <div class="top-bar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="icon-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
@@ -35,6 +33,7 @@
     <main>
         <section class="tool-container">
             <div class="container">
+                <a href="../index.html" class="back-link">all tools</a>
                 <div class="tool-header">
                     <h1>CURL Constructor</h1>
                 </div>

--- a/tools/hash-generator.html
+++ b/tools/hash-generator.html
@@ -17,12 +17,10 @@
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a href="../index.html" class="brand">devtools</a>
-        <span class="top-bar__crumb-sep">/</span>
-        <span class="top-bar__crumb-current" id="tool-crumb"></span>
-        <div class="toolbar__spacer"></div>
+        <a href="../index.html" class="top-bar__brand">devtools</a>
+        <div class="top-bar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="icon-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
@@ -35,6 +33,7 @@
     <main>
         <section class="tool-container">
             <div class="container">
+                <a href="../index.html" class="back-link">all tools</a>
                 <div class="tool-header">
                     <h1>Hash Generator</h1>
                 </div>

--- a/tools/ip-lookup.html
+++ b/tools/ip-lookup.html
@@ -16,12 +16,10 @@
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a href="../index.html" class="brand">devtools</a>
-        <span class="top-bar__crumb-sep">/</span>
-        <span class="top-bar__crumb-current" id="tool-crumb"></span>
-        <div class="toolbar__spacer"></div>
+        <a href="../index.html" class="top-bar__brand">devtools</a>
+        <div class="top-bar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="icon-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
@@ -34,6 +32,7 @@
     <main>
         <section class="tool-container">
             <div class="container">
+                <a href="../index.html" class="back-link">all tools</a>
                 <div class="tool-header">
                     <h1>IP Address Lookup</h1>
                 </div>

--- a/tools/json-formatter.html
+++ b/tools/json-formatter.html
@@ -20,12 +20,10 @@
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a href="../index.html" class="brand">devtools</a>
-        <span class="top-bar__crumb-sep">/</span>
-        <span class="top-bar__crumb-current" id="tool-crumb"></span>
-        <div class="toolbar__spacer"></div>
+        <a href="../index.html" class="top-bar__brand">devtools</a>
+        <div class="top-bar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="icon-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
@@ -38,6 +36,7 @@
     <main>
         <section class="tool-container">
             <div class="container">
+                <a href="../index.html" class="back-link">all tools</a>
                 <div class="tool-header">
                     <h1>JSON Beautifier/Minifier</h1>
                 </div>

--- a/tools/json-to-protobuf.html
+++ b/tools/json-to-protobuf.html
@@ -17,12 +17,10 @@
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a href="../index.html" class="brand">devtools</a>
-        <span class="top-bar__crumb-sep">/</span>
-        <span class="top-bar__crumb-current" id="tool-crumb"></span>
-        <div class="toolbar__spacer"></div>
+        <a href="../index.html" class="top-bar__brand">devtools</a>
+        <div class="top-bar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="icon-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
@@ -35,6 +33,7 @@
     <main>
         <section class="tool-container">
             <div class="container">
+                <a href="../index.html" class="back-link">all tools</a>
                 <div class="tool-header">
                     <h1>JSON to Protocol Buffer Generator</h1>
                 </div>

--- a/tools/json-yaml-converter.html
+++ b/tools/json-yaml-converter.html
@@ -17,12 +17,10 @@
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a href="../index.html" class="brand">devtools</a>
-        <span class="top-bar__crumb-sep">/</span>
-        <span class="top-bar__crumb-current" id="tool-crumb"></span>
-        <div class="toolbar__spacer"></div>
+        <a href="../index.html" class="top-bar__brand">devtools</a>
+        <div class="top-bar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="icon-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
@@ -35,6 +33,7 @@
     <main>
         <section class="tool-container">
             <div class="container">
+                <a href="../index.html" class="back-link">all tools</a>
                 <div class="tool-header">
                     <h1>JSON <-> YAML Converter</h1>
                 </div>

--- a/tools/json-yaml-explorer.html
+++ b/tools/json-yaml-explorer.html
@@ -22,12 +22,10 @@
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a href="../index.html" class="brand">devtools</a>
-        <span class="top-bar__crumb-sep">/</span>
-        <span class="top-bar__crumb-current" id="tool-crumb"></span>
-        <div class="toolbar__spacer"></div>
+        <a href="../index.html" class="top-bar__brand">devtools</a>
+        <div class="top-bar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="icon-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
@@ -40,6 +38,7 @@
     <main>
         <section class="tool-container">
             <div class="container">
+                <a href="../index.html" class="back-link">all tools</a>
                 <div class="tool-header">
                     <h1>JSON/YAML Explorer</h1>
                 </div>

--- a/tools/jwt-decoder.html
+++ b/tools/jwt-decoder.html
@@ -17,12 +17,10 @@
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a href="../index.html" class="brand">devtools</a>
-        <span class="top-bar__crumb-sep">/</span>
-        <span class="top-bar__crumb-current" id="tool-crumb"></span>
-        <div class="toolbar__spacer"></div>
+        <a href="../index.html" class="top-bar__brand">devtools</a>
+        <div class="top-bar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="icon-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
@@ -35,6 +33,7 @@
     <main>
         <section class="tool-container">
             <div class="container">
+                <a href="../index.html" class="back-link">all tools</a>
                 <div class="tool-header">
                     <h1>JWT Decoder</h1>
                 </div>

--- a/tools/line-sort-dedupe.html
+++ b/tools/line-sort-dedupe.html
@@ -17,12 +17,10 @@
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a href="../index.html" class="brand">devtools</a>
-        <span class="top-bar__crumb-sep">/</span>
-        <span class="top-bar__crumb-current" id="tool-crumb"></span>
-        <div class="toolbar__spacer"></div>
+        <a href="../index.html" class="top-bar__brand">devtools</a>
+        <div class="top-bar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="icon-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
@@ -35,6 +33,7 @@
     <main>
         <section class="tool-container">
             <div class="container">
+                <a href="../index.html" class="back-link">all tools</a>
                 <div class="tool-header">
                     <h1>Line Sort/Dedupe</h1>
                 </div>

--- a/tools/markdown-preview.html
+++ b/tools/markdown-preview.html
@@ -179,12 +179,10 @@
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a href="../index.html" class="brand">devtools</a>
-        <span class="top-bar__crumb-sep">/</span>
-        <span class="top-bar__crumb-current" id="tool-crumb"></span>
-        <div class="toolbar__spacer"></div>
+        <a href="../index.html" class="top-bar__brand">devtools</a>
+        <div class="top-bar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="icon-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
@@ -197,6 +195,7 @@
     <main>
         <section class="tool-container">
             <div class="container">
+                <a href="../index.html" class="back-link">all tools</a>
                 <div class="tool-header">
                     <h1>Markdown Preview</h1>
                 </div>

--- a/tools/mermaid-diagram-editor.html
+++ b/tools/mermaid-diagram-editor.html
@@ -131,12 +131,10 @@
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a href="../index.html" class="brand">devtools</a>
-        <span class="top-bar__crumb-sep">/</span>
-        <span class="top-bar__crumb-current" id="tool-crumb"></span>
-        <div class="toolbar__spacer"></div>
+        <a href="../index.html" class="top-bar__brand">devtools</a>
+        <div class="top-bar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="icon-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
@@ -149,6 +147,7 @@
     <main>
         <section class="tool-container">
             <div class="container">
+                <a href="../index.html" class="back-link">all tools</a>
                 <div class="tool-header">
                     <h1>Mermaid Diagram Editor</h1>
                 </div>

--- a/tools/ocr-tool.html
+++ b/tools/ocr-tool.html
@@ -102,12 +102,10 @@
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a href="../index.html" class="brand">devtools</a>
-        <span class="top-bar__crumb-sep">/</span>
-        <span class="top-bar__crumb-current" id="tool-crumb"></span>
-        <div class="toolbar__spacer"></div>
+        <a href="../index.html" class="top-bar__brand">devtools</a>
+        <div class="top-bar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="icon-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
@@ -120,6 +118,7 @@
     <main>
         <section class="tool-container">
             <div class="container">
+                <a href="../index.html" class="back-link">all tools</a>
                 <div class="tool-header">
                     <h1>OCR Tool</h1>
                 </div>

--- a/tools/password-generator.html
+++ b/tools/password-generator.html
@@ -17,12 +17,10 @@
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a href="../index.html" class="brand">devtools</a>
-        <span class="top-bar__crumb-sep">/</span>
-        <span class="top-bar__crumb-current" id="tool-crumb"></span>
-        <div class="toolbar__spacer"></div>
+        <a href="../index.html" class="top-bar__brand">devtools</a>
+        <div class="top-bar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="icon-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
@@ -35,6 +33,7 @@
     <main>
         <section class="tool-container">
             <div class="container">
+                <a href="../index.html" class="back-link">all tools</a>
                 <div class="tool-header">
                     <h1>Random Password Generator</h1>
                 </div>

--- a/tools/qr-code-tool.html
+++ b/tools/qr-code-tool.html
@@ -21,12 +21,10 @@
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a href="../index.html" class="brand">devtools</a>
-        <span class="top-bar__crumb-sep">/</span>
-        <span class="top-bar__crumb-current" id="tool-crumb"></span>
-        <div class="toolbar__spacer"></div>
+        <a href="../index.html" class="top-bar__brand">devtools</a>
+        <div class="top-bar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="icon-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
@@ -39,6 +37,7 @@
     <main>
         <section class="tool-container">
             <div class="container">
+                <a href="../index.html" class="back-link">all tools</a>
                 <div class="tool-header">
                     <h1>QR Code Reader/Generator</h1>
                 </div>

--- a/tools/regex-tester.html
+++ b/tools/regex-tester.html
@@ -17,12 +17,10 @@
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a href="../index.html" class="brand">devtools</a>
-        <span class="top-bar__crumb-sep">/</span>
-        <span class="top-bar__crumb-current" id="tool-crumb"></span>
-        <div class="toolbar__spacer"></div>
+        <a href="../index.html" class="top-bar__brand">devtools</a>
+        <div class="top-bar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="icon-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
@@ -35,6 +33,7 @@
     <main>
         <section class="tool-container">
             <div class="container">
+                <a href="../index.html" class="back-link">all tools</a>
                 <div class="tool-header">
                     <h1>Regular Expression Tester</h1>
                 </div>

--- a/tools/secret-share.html
+++ b/tools/secret-share.html
@@ -17,12 +17,10 @@
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a href="../index.html" class="brand">devtools</a>
-        <span class="top-bar__crumb-sep">/</span>
-        <span class="top-bar__crumb-current" id="tool-crumb"></span>
-        <div class="toolbar__spacer"></div>
+        <a href="../index.html" class="top-bar__brand">devtools</a>
+        <div class="top-bar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="icon-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
@@ -35,6 +33,7 @@
     <main>
         <section class="tool-container">
             <div class="container">
+                <a href="../index.html" class="back-link">all tools</a>
                 <div class="tool-header">
                     <h1>Secret Share</h1>
                 </div>

--- a/tools/ssl-checker.html
+++ b/tools/ssl-checker.html
@@ -16,12 +16,10 @@
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a href="../index.html" class="brand">devtools</a>
-        <span class="top-bar__crumb-sep">/</span>
-        <span class="top-bar__crumb-current" id="tool-crumb"></span>
-        <div class="toolbar__spacer"></div>
+        <a href="../index.html" class="top-bar__brand">devtools</a>
+        <div class="top-bar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="icon-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
@@ -34,6 +32,7 @@
     <main>
         <section class="tool-container">
             <div class="container">
+                <a href="../index.html" class="back-link">all tools</a>
                 <div class="tool-header">
                     <h1>SSL/TLS Certificate Checker</h1>
                 </div>

--- a/tools/string-case-converter.html
+++ b/tools/string-case-converter.html
@@ -17,12 +17,10 @@
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a href="../index.html" class="brand">devtools</a>
-        <span class="top-bar__crumb-sep">/</span>
-        <span class="top-bar__crumb-current" id="tool-crumb"></span>
-        <div class="toolbar__spacer"></div>
+        <a href="../index.html" class="top-bar__brand">devtools</a>
+        <div class="top-bar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="icon-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
@@ -35,6 +33,7 @@
     <main>
         <section class="tool-container">
             <div class="container">
+                <a href="../index.html" class="back-link">all tools</a>
                 <div class="tool-header">
                     <h1>String Case Converter</h1>
                 </div>

--- a/tools/string-generator.html
+++ b/tools/string-generator.html
@@ -17,12 +17,10 @@
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a href="../index.html" class="brand">devtools</a>
-        <span class="top-bar__crumb-sep">/</span>
-        <span class="top-bar__crumb-current" id="tool-crumb"></span>
-        <div class="toolbar__spacer"></div>
+        <a href="../index.html" class="top-bar__brand">devtools</a>
+        <div class="top-bar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="icon-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
@@ -35,6 +33,7 @@
     <main>
         <section class="tool-container">
             <div class="container">
+                <a href="../index.html" class="back-link">all tools</a>
                 <div class="tool-header">
                     <h1>Random String Generator</h1>
                 </div>

--- a/tools/subnet-calculator.html
+++ b/tools/subnet-calculator.html
@@ -16,12 +16,10 @@
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a href="../index.html" class="brand">devtools</a>
-        <span class="top-bar__crumb-sep">/</span>
-        <span class="top-bar__crumb-current" id="tool-crumb"></span>
-        <div class="toolbar__spacer"></div>
+        <a href="../index.html" class="top-bar__brand">devtools</a>
+        <div class="top-bar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="icon-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
@@ -34,6 +32,7 @@
     <main>
         <section class="tool-container">
             <div class="container">
+                <a href="../index.html" class="back-link">all tools</a>
                 <div class="tool-header">
                     <h1>Subnet Calculator</h1>
                 </div>

--- a/tools/text-diff.html
+++ b/tools/text-diff.html
@@ -105,12 +105,10 @@
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a href="../index.html" class="brand">devtools</a>
-        <span class="top-bar__crumb-sep">/</span>
-        <span class="top-bar__crumb-current" id="tool-crumb"></span>
-        <div class="toolbar__spacer"></div>
+        <a href="../index.html" class="top-bar__brand">devtools</a>
+        <div class="top-bar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="icon-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
@@ -123,6 +121,7 @@
     <main>
         <section class="tool-container">
             <div class="container">
+                <a href="../index.html" class="back-link">all tools</a>
                 <div class="tool-header">
                     <h1>Text Diff Utility</h1>
                 </div>

--- a/tools/timestamp-converter.html
+++ b/tools/timestamp-converter.html
@@ -17,12 +17,10 @@
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a href="../index.html" class="brand">devtools</a>
-        <span class="top-bar__crumb-sep">/</span>
-        <span class="top-bar__crumb-current" id="tool-crumb"></span>
-        <div class="toolbar__spacer"></div>
+        <a href="../index.html" class="top-bar__brand">devtools</a>
+        <div class="top-bar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="icon-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
@@ -35,6 +33,7 @@
     <main>
         <section class="tool-container">
             <div class="container">
+                <a href="../index.html" class="back-link">all tools</a>
                 <div class="tool-header">
                     <h1>Timestamp Converter</h1>
                 </div>

--- a/tools/url-encoder-decoder.html
+++ b/tools/url-encoder-decoder.html
@@ -17,12 +17,10 @@
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a href="../index.html" class="brand">devtools</a>
-        <span class="top-bar__crumb-sep">/</span>
-        <span class="top-bar__crumb-current" id="tool-crumb"></span>
-        <div class="toolbar__spacer"></div>
+        <a href="../index.html" class="top-bar__brand">devtools</a>
+        <div class="top-bar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="icon-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
@@ -35,6 +33,7 @@
     <main>
         <section class="tool-container">
             <div class="container">
+                <a href="../index.html" class="back-link">all tools</a>
                 <div class="tool-header">
                     <h1>URL Encoder/Decoder</h1>
                 </div>

--- a/tools/url-parser.html
+++ b/tools/url-parser.html
@@ -17,12 +17,10 @@
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a href="../index.html" class="brand">devtools</a>
-        <span class="top-bar__crumb-sep">/</span>
-        <span class="top-bar__crumb-current" id="tool-crumb"></span>
-        <div class="toolbar__spacer"></div>
+        <a href="../index.html" class="top-bar__brand">devtools</a>
+        <div class="top-bar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="icon-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
@@ -35,6 +33,7 @@
     <main>
         <section class="tool-container">
             <div class="container">
+                <a href="../index.html" class="back-link">all tools</a>
                 <div class="tool-header">
                     <h1>URL Parser</h1>
                 </div>

--- a/tools/url-to-markdown.html
+++ b/tools/url-to-markdown.html
@@ -17,12 +17,10 @@
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a href="../index.html" class="brand">devtools</a>
-        <span class="top-bar__crumb-sep">/</span>
-        <span class="top-bar__crumb-current" id="tool-crumb"></span>
-        <div class="toolbar__spacer"></div>
+        <a href="../index.html" class="top-bar__brand">devtools</a>
+        <div class="top-bar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="icon-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
@@ -35,6 +33,7 @@
     <main>
         <section class="tool-container">
             <div class="container">
+                <a href="../index.html" class="back-link">all tools</a>
                 <div class="tool-header">
                     <h1>URL to Markdown</h1>
                 </div>

--- a/tools/uuid-generator.html
+++ b/tools/uuid-generator.html
@@ -17,12 +17,10 @@
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a href="../index.html" class="brand">devtools</a>
-        <span class="top-bar__crumb-sep">/</span>
-        <span class="top-bar__crumb-current" id="tool-crumb"></span>
-        <div class="toolbar__spacer"></div>
+        <a href="../index.html" class="top-bar__brand">devtools</a>
+        <div class="top-bar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="icon-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
@@ -35,6 +33,7 @@
     <main>
         <section class="tool-container">
             <div class="container">
+                <a href="../index.html" class="back-link">all tools</a>
                 <div class="tool-header">
                     <h1>UUID Generator</h1>
                 </div>

--- a/tools/vim-editor.html
+++ b/tools/vim-editor.html
@@ -369,12 +369,10 @@
 </head>
 <body class="tool-page-shell">
     <header class="top-bar">
-        <a href="../index.html" class="brand">devtools</a>
-        <span class="top-bar__crumb-sep">/</span>
-        <span class="top-bar__crumb-current" id="tool-crumb"></span>
-        <div class="toolbar__spacer"></div>
+        <a href="../index.html" class="top-bar__brand">devtools</a>
+        <div class="top-bar__spacer"></div>
         <div class="top-bar__actions">
-            <a class="theme-toggle-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
+            <a class="icon-btn" href="https://github.com/irfansofyana/Devtools" target="_blank" rel="noopener" aria-label="GitHub repository">
                 <i class="fab fa-github" aria-hidden="true"></i>
             </a>
             <button class="theme-toggle-btn" id="theme-toggle-btn" aria-label="Toggle dark and light theme" aria-pressed="false">
@@ -387,6 +385,7 @@
     <main>
         <section class="tool-container">
             <div class="container">
+                <a href="../index.html" class="back-link">all tools</a>
                 <div class="tool-header">
                     <h1>Vim-Style Code Editor</h1>
                 </div>


### PR DESCRIPTION
## Summary

Replaces the merged-border tool grid, numbered headers, and `$/~` terminal flourishes from #6 with a calmer personal-dev-site layout. Then adds proper responsive breakpoints so it holds up on phones and touch devices.

### Layout
- **Narrow centered column** (~720 px), system sans body, JetBrains Mono only on labels, the brand wordmark, and tool names.
- **Plain two-column row list** per category — mono slug-style tool name on the left (`json-formatter`, `subnet`, `ascii-hex`), prose description on the right. No cards, no merged borders, just a subtle hover background.
- **Quiet section headers**: small uppercase mono labels with a hairline rule. No `01 / 02 / 03` numbering.
- **Tool pages**: plain `← all tools` back link instead of the brand+slugified-breadcrumb header.

### Identity
- Quiet accent: muted blue (`#2563eb` light, `#60a5fa` dark) on links and hover. The vermilion is gone.
- Footer is one inline line. Header is `devtools` + GitHub + theme toggle.

### Keyboard
- `/` and `⌘K`/`Ctrl+K` both focus search.
- `Esc` clears.

### Responsive (4 breakpoints + coarse pointer)
| Width | Change |
|---|---|
| ≤880 px | Tool-row name column tightens to 11 rem so descriptions don't get squeezed |
| ≤640 px | Rows stack vertically, h1 scales down, search input → 44 px, header icon buttons → 40 px (touch targets), reduced side padding |
| ≤380 px | Side padding pulls in further; header gap tightens |
| `pointer: coarse` | Header icon buttons stay 40 px on any touch device regardless of viewport width |

Plus the existing `prefers-reduced-motion` handling.

Net: –535 lines (43 files, +621 / –1156) for the simplification + 76 lines for the responsive pass.

## Test plan

- [ ] Open `index.html` — verify the narrow centered column, quiet blue links, and per-category row lists render. Hover a tool — name turns blue, row gets a tint.
- [ ] Type `json` in the search — only the Data section stays visible, other sections collapse. Hit `/` from anywhere on the page — search focuses. `Esc` clears it.
- [ ] Toggle theme (sun/moon icon, top-right). Confirm the muted blue and dark surfaces both read well.
- [ ] Open a tool page (`tools/json-formatter.html`); confirm the `← all tools` back link sits above the title and the same minimal header is in place.
- [ ] Resize the browser to ~768 px → name column tightens; ~640 px → rows stack; ~360 px → side padding collapses to fit; everything stays readable.
- [ ] Open in Chrome DevTools mobile emulation (any device) — header icon buttons should be 40 px and easy to tap.
- [ ] Paste invalid JSON in `tools/json-formatter.html` to confirm error alerts still announce; paste valid JSON, hit Beautify + Copy to confirm clipboard still works (regression check from #5's fix).

https://claude.ai/code/session_01H5uqb6eqt5ZQnjuNHHQ1vT

---
_Generated by [Claude Code](https://claude.ai/code/session_01H5uqb6eqt5ZQnjuNHHQ1vT)_